### PR TITLE
feat: implement modular form builder experience

### DIFF
--- a/wp-betterforms/src/admin/components/BuilderCanvas.tsx
+++ b/wp-betterforms/src/admin/components/BuilderCanvas.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useMemo, useRef } from 'react';
+import type { FormField } from '../types';
+import { FIELD_PALETTE_DATA_TYPE, PalettePayload } from './FieldPalette';
+import { addFieldAt, createField, DropLocation, moveField } from '../utils/schema';
+
+const NODE_DATA_TYPE = 'application/x-bf-field-node';
+
+export interface BuilderCanvasProps {
+  fields: FormField[];
+  selectedFieldId: string | null;
+  onChange: (fields: FormField[]) => void;
+  onSelect: (fieldId: string | null) => void;
+  onCreate: (field: FormField) => void;
+}
+
+interface DropPayload {
+  mode: 'move';
+  fieldId: string;
+}
+
+type DragPayload = PalettePayload | DropPayload;
+
+function parsePayload(event: React.DragEvent<HTMLElement>): DragPayload | null {
+  const paletteData = event.dataTransfer.getData(FIELD_PALETTE_DATA_TYPE);
+  if (paletteData) {
+    try {
+      return JSON.parse(paletteData) as PalettePayload;
+    } catch (error) {
+      console.error('Unable to parse palette payload', error);
+      return null;
+    }
+  }
+
+  const nodeData = event.dataTransfer.getData(NODE_DATA_TYPE);
+  if (nodeData) {
+    try {
+      return JSON.parse(nodeData) as DropPayload;
+    } catch (error) {
+      console.error('Unable to parse node payload', error);
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function BuilderCanvas({ fields, selectedFieldId, onChange, onSelect, onCreate }: BuilderCanvasProps) {
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+
+  const announce = useCallback((message: string) => {
+    const region = liveRegionRef.current;
+    if (!region) {
+      return;
+    }
+    region.textContent = '';
+    window.requestAnimationFrame(() => {
+      region.textContent = message;
+    });
+  }, []);
+
+  const handleDrop = useCallback(
+    (location: DropLocation) =>
+      (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const payload = parsePayload(event);
+        if (!payload) {
+          return;
+        }
+
+        if (payload.mode === 'create') {
+          const field = createField(payload.fieldType);
+          onChange(addFieldAt(fields, field, location));
+          onCreate(field);
+          announce(`Added ${payload.fieldType} field.`);
+          return;
+        }
+
+        if (payload.mode === 'move') {
+          if (payload.fieldId === undefined) {
+            return;
+          }
+          onChange(moveField(fields, payload.fieldId, location));
+          announce('Field moved.');
+        }
+      },
+    [announce, fields, onChange, onCreate],
+  );
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    const payload = parsePayload(event);
+    event.preventDefault();
+    event.dataTransfer.dropEffect = payload?.mode === 'create' ? 'copy' : 'move';
+  }, []);
+
+  const handleDragStart = useCallback((fieldId: string) => (event: React.DragEvent<HTMLButtonElement>) => {
+    const payload: DropPayload = { mode: 'move', fieldId };
+    event.dataTransfer.setData(NODE_DATA_TYPE, JSON.stringify(payload));
+    event.dataTransfer.effectAllowed = 'move';
+  }, []);
+
+  const fieldOptions = useMemo(() => fields.length, [fields]);
+
+  return (
+    <section className="bf-canvas" aria-label="Form builder canvas">
+      <div className="bf-canvas__dropzone" onDrop={handleDrop({ parentId: null, index: 0 })} onDragOver={handleDragOver}>
+        {fields.length === 0 && <p>Drag fields here or select one from the palette to get started.</p>}
+      </div>
+      <div className="bf-canvas__list" role="list">
+        {fields.map((field, index) => (
+          <FieldNode
+            key={field.id}
+            field={field}
+            index={index}
+            parentId={null}
+            depth={0}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragStart={handleDragStart}
+            onSelect={onSelect}
+            selectedFieldId={selectedFieldId}
+          />
+        ))}
+      </div>
+      <div className="bf-canvas__dropzone" onDrop={handleDrop({ parentId: null, index: fieldOptions })} onDragOver={handleDragOver}>
+        <p>Add field to the end of the form.</p>
+      </div>
+      <div ref={liveRegionRef} className="sr-only" aria-live="polite" aria-atomic="true" />
+    </section>
+  );
+}
+
+interface FieldNodeProps {
+  field: FormField;
+  index: number;
+  parentId: string | null;
+  depth: number;
+  selectedFieldId: string | null;
+  onDrop: (location: DropLocation) => (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragStart: (fieldId: string) => (event: React.DragEvent<HTMLButtonElement>) => void;
+  onSelect: (fieldId: string | null) => void;
+}
+
+function FieldNode({
+  field,
+  index,
+  parentId,
+  depth,
+  selectedFieldId,
+  onDrop,
+  onDragOver,
+  onDragStart,
+  onSelect,
+}: FieldNodeProps) {
+  const isSelected = field.id === selectedFieldId;
+  const dropBefore = useMemo<DropLocation>(() => ({ parentId, index }), [index, parentId]);
+  const dropAfter = useMemo<DropLocation>(() => ({ parentId, index: index + 1 }), [index, parentId]);
+  const childDrop = useMemo<DropLocation>(() => ({ parentId: field.id, index: field.children?.length ?? 0 }), [field.children?.length, field.id]);
+
+  return (
+    <div className={`bf-field-node ${isSelected ? 'is-selected' : ''}`} role="listitem">
+      <div className="bf-drop-target" onDrop={onDrop(dropBefore)} onDragOver={onDragOver} aria-hidden="true" />
+      <div className="bf-field-node__body" data-depth={depth}>
+        <div className="bf-field-node__header">
+          <button
+            type="button"
+            className="bf-field-node__drag"
+            aria-label={`Drag handle for ${field.label}`}
+            draggable
+            onDragStart={onDragStart(field.id)}
+          >
+            ::
+          </button>
+          <button
+            type="button"
+            className="bf-field-node__label"
+            onClick={() => onSelect(field.id)}
+            aria-pressed={isSelected}
+          >
+            <span className="bf-field-node__type">{field.type}</span>
+            <span className="bf-field-node__name">{field.label}</span>
+          </button>
+        </div>
+        {field.children && (
+          <div className="bf-field-node__children" aria-label={`Children for ${field.label}`}>
+            {field.children.map((child, childIndex) => (
+              <FieldNode
+                key={child.id}
+                field={child}
+                index={childIndex}
+                parentId={field.id}
+                depth={depth + 1}
+                selectedFieldId={selectedFieldId}
+                onDrop={onDrop}
+                onDragOver={onDragOver}
+                onDragStart={onDragStart}
+                onSelect={onSelect}
+              />
+            ))}
+            <div className="bf-drop-target is-inner" onDrop={onDrop(childDrop)} onDragOver={onDragOver}>
+              <p>Add fields inside this repeater</p>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="bf-drop-target" onDrop={onDrop(dropAfter)} onDragOver={onDragOver} aria-hidden="true" />
+    </div>
+  );
+}

--- a/wp-betterforms/src/admin/components/FieldInspector.tsx
+++ b/wp-betterforms/src/admin/components/FieldInspector.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import type { FormField } from '../types';
+
+export interface FieldInspectorProps {
+  field: FormField | null;
+  onChange: (fieldId: string, updates: Partial<FormField>) => void;
+  onDelete: (fieldId: string) => void;
+}
+
+export function FieldInspector({ field, onChange, onDelete }: FieldInspectorProps) {
+  const labelRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (field && labelRef.current) {
+      labelRef.current.focus();
+    }
+  }, [field]);
+
+  if (!field) {
+    return (
+      <aside className="bf-inspector" aria-label="Field inspector">
+        <p>Select a field to edit its settings.</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="bf-inspector" aria-label="Field inspector">
+      <header className="bf-panel-heading-group">
+        <h2 className="bf-panel-heading">{field.label || 'Field'}</h2>
+        <button type="button" className="bf-button-danger" onClick={() => onDelete(field.id)}>
+          Remove field
+        </button>
+      </header>
+      <label>
+        Label
+        <input
+          ref={labelRef}
+          type="text"
+          value={field.label}
+          onChange={(event) => onChange(field.id, { label: event.target.value })}
+        />
+      </label>
+      <label>
+        Placeholder
+        <input
+          type="text"
+          value={field.placeholder ?? ''}
+          onChange={(event) => onChange(field.id, { placeholder: event.target.value })}
+        />
+      </label>
+      <label>
+        Help text
+        <textarea
+          value={field.helpText ?? ''}
+          onChange={(event) => onChange(field.id, { helpText: event.target.value })}
+        />
+      </label>
+      <label className="bf-field-toggle">
+        <input
+          type="checkbox"
+          checked={Boolean(field.required)}
+          onChange={(event) => onChange(field.id, { required: event.target.checked })}
+        />
+        Required
+      </label>
+      {(field.type === 'checkbox' || field.type === 'select') && field.options && (
+        <div className="bf-inspector__options">
+          <h3>Options</h3>
+          <ul>
+            {field.options.map((option, index) => (
+              <li key={option.id}>
+                <input
+                  type="text"
+                  value={option.label}
+                  onChange={(event) => {
+                    const next = [...field.options!];
+                    next[index] = { ...option, label: event.target.value };
+                    onChange(field.id, { options: next });
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="bf-button-secondary"
+            onClick={() =>
+              onChange(field.id, {
+                options: [
+                  ...(field.options ?? []),
+                  { id: crypto.randomUUID(), label: `Option ${field.options.length + 1}` },
+                ],
+              })
+            }
+          >
+            Add option
+          </button>
+        </div>
+      )}
+      {field.type === 'repeater' && <p>This repeater supports nested fields. Drag items onto it from the palette.</p>}
+    </aside>
+  );
+}

--- a/wp-betterforms/src/admin/components/FieldPalette.tsx
+++ b/wp-betterforms/src/admin/components/FieldPalette.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import type { FieldType } from '../types';
+
+const CATALOG: { type: FieldType; label: string; description: string }[] = [
+  { type: 'text', label: 'Text', description: 'Single line text input.' },
+  { type: 'textarea', label: 'Paragraph', description: 'Multi-line textarea.' },
+  { type: 'email', label: 'Email', description: 'Email address field with validation.' },
+  { type: 'number', label: 'Number', description: 'Numeric input supporting step configuration.' },
+  { type: 'checkbox', label: 'Checkboxes', description: 'Multiple selection checkboxes.' },
+  { type: 'select', label: 'Dropdown', description: 'Single selection dropdown menu.' },
+  { type: 'repeater', label: 'Repeater', description: 'Nested section that can repeat fields.' },
+];
+
+export const FIELD_PALETTE_DATA_TYPE = 'application/x-bf-palette-field';
+
+export interface FieldPaletteProps {
+  onAdd: (type: FieldType) => void;
+}
+
+export function FieldPalette({ onAdd }: FieldPaletteProps) {
+  const items = useMemo(() => CATALOG, []);
+
+  return (
+    <aside className="bf-palette" aria-label="Field palette">
+      <h2 className="bf-panel-heading">Fields</h2>
+      <ul className="bf-palette__list">
+        {items.map((item) => (
+          <li key={item.type}>
+            <button
+              type="button"
+              className="bf-palette__item"
+              draggable
+              onDragStart={(event) => {
+                event.dataTransfer.effectAllowed = 'copy';
+                event.dataTransfer.setData(
+                  FIELD_PALETTE_DATA_TYPE,
+                  JSON.stringify({ mode: 'create', fieldType: item.type }),
+                );
+              }}
+              onClick={() => onAdd(item.type)}
+            >
+              <span className="bf-palette__item-label">{item.label}</span>
+              <span className="bf-palette__item-description">{item.description}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+export type PalettePayload = {
+  mode: 'create';
+  fieldType: FieldType;
+};

--- a/wp-betterforms/src/admin/components/FormList.tsx
+++ b/wp-betterforms/src/admin/components/FormList.tsx
@@ -1,0 +1,66 @@
+import { useRef } from 'react';
+import { useForms } from '../hooks/useForms';
+
+export interface FormListProps {
+  onCreate: () => void;
+  onOpen: (formId: number) => void;
+}
+
+export function FormList({ onCreate, onOpen }: FormListProps) {
+  const { forms, loading, error, refresh } = useForms();
+  const liveRef = useRef<HTMLParagraphElement>(null);
+
+  return (
+    <section className="bf-admin-panel" aria-label="Forms">
+      <header className="bf-admin-panel__header">
+        <div>
+          <h1>WP Better Forms</h1>
+          <p className="bf-admin-panel__subtitle">Design dynamic, accessible forms with conditional logic and advanced styling.</p>
+        </div>
+        <div className="bf-admin-panel__actions">
+          <button type="button" className="bf-button-secondary" onClick={() => refresh()} disabled={loading}>
+            Refresh
+          </button>
+          <button type="button" onClick={onCreate} className="bf-button">
+            New form
+          </button>
+        </div>
+      </header>
+      {loading && (
+        <p role="status" ref={liveRef} aria-live="polite">
+          Loading forms…
+        </p>
+      )}
+      {error && (
+        <p className="bf-error" role="alert">
+          {error}
+        </p>
+      )}
+      <ul className="bf-form-list" role="list">
+        {forms.map((form) => (
+          <li key={form.id}>
+            <div>
+              <p className="bf-form-list__title">{form.title}</p>
+              <p className="bf-form-list__meta">
+                <span>{form.status}</span>
+                {(() => {
+                  const timestamp = new Date(form.updated_at);
+                  const label = Number.isNaN(timestamp.getTime())
+                    ? 'Never updated'
+                    : `Updated ${timestamp.toLocaleString()}`;
+                  return <time dateTime={form.updated_at || ''}>{label}</time>;
+                })()}
+              </p>
+            </div>
+            <div className="bf-form-list__actions">
+              <button type="button" className="bf-button-secondary" onClick={() => onOpen(form.id)}>
+                Edit
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {forms.length === 0 && !loading && <p>No forms yet. Create one to get started.</p>}
+    </section>
+  );
+}

--- a/wp-betterforms/src/admin/components/IntegrationsPanel.tsx
+++ b/wp-betterforms/src/admin/components/IntegrationsPanel.tsx
@@ -1,0 +1,78 @@
+import type { IntegrationSettings } from '../types';
+
+export interface IntegrationsPanelProps {
+  integrations: IntegrationSettings;
+  onChange: (value: IntegrationSettings) => void;
+}
+
+export function IntegrationsPanel({ integrations, onChange }: IntegrationsPanelProps) {
+  const update = <K extends keyof IntegrationSettings>(key: K, value: IntegrationSettings[K]) => {
+    onChange({ ...integrations, [key]: value });
+  };
+
+  return (
+    <section className="bf-integrations" aria-label="Integrations">
+      <h2 className="bf-panel-heading">Integrations</h2>
+      <fieldset>
+        <legend>Email notifications</legend>
+        <label>
+          <input
+            type="checkbox"
+            checked={integrations.emailNotifications.enabled}
+            onChange={(event) =>
+              update('emailNotifications', {
+                ...integrations.emailNotifications,
+                enabled: event.target.checked,
+              })
+            }
+          />
+          Enabled
+        </label>
+        <label>
+          Recipients
+          <input
+            type="text"
+            value={integrations.emailNotifications.recipients}
+            onChange={(event) =>
+              update('emailNotifications', {
+                ...integrations.emailNotifications,
+                recipients: event.target.value,
+              })
+            }
+            placeholder="editor@example.com"
+          />
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>Webhook</legend>
+        <label>
+          <input
+            type="checkbox"
+            checked={integrations.webhook.enabled}
+            onChange={(event) =>
+              update('webhook', {
+                ...integrations.webhook,
+                enabled: event.target.checked,
+              })
+            }
+          />
+          Enabled
+        </label>
+        <label>
+          URL
+          <input
+            type="url"
+            value={integrations.webhook.url}
+            onChange={(event) =>
+              update('webhook', {
+                ...integrations.webhook,
+                url: event.target.value,
+              })
+            }
+            placeholder="https://example.com/webhook"
+          />
+        </label>
+      </fieldset>
+    </section>
+  );
+}

--- a/wp-betterforms/src/admin/components/LogicEditor.tsx
+++ b/wp-betterforms/src/admin/components/LogicEditor.tsx
@@ -1,0 +1,142 @@
+import { useMemo } from 'react';
+import type { FormField, FormLogic, LogicRule } from '../types';
+import { flattenFields } from '../utils/schema';
+
+export interface LogicEditorProps {
+  logic: FormLogic;
+  fields: FormField[];
+  onChange: (logic: FormLogic) => void;
+}
+
+const OPERATORS: { value: LogicRule['operator']; label: string }[] = [
+  { value: 'equals', label: 'equals' },
+  { value: 'not_equals', label: 'does not equal' },
+  { value: 'contains', label: 'contains' },
+  { value: 'greater_than', label: 'is greater than' },
+  { value: 'less_than', label: 'is less than' },
+];
+
+const ACTIONS: { value: LogicRule['action']; label: string }[] = [
+  { value: 'show', label: 'show field' },
+  { value: 'hide', label: 'hide field' },
+  { value: 'enable', label: 'enable field' },
+  { value: 'disable', label: 'disable field' },
+];
+
+export function LogicEditor({ logic, fields, onChange }: LogicEditorProps) {
+  const flatFields = useMemo(
+    () =>
+      flattenFields(fields).map((field) => ({
+        id: field.id,
+        label: field.label,
+      })),
+    [fields],
+  );
+
+  const updateRule = (rule: LogicRule, index: number) => {
+    const nextRules = [...logic.rules];
+    nextRules[index] = rule;
+    onChange({ rules: nextRules });
+  };
+
+  const removeRule = (index: number) => {
+    const nextRules = [...logic.rules];
+    nextRules.splice(index, 1);
+    onChange({ rules: nextRules });
+  };
+
+  const addRule = () => {
+    const firstField = flatFields[0];
+    const id = crypto.randomUUID();
+    const rule: LogicRule = {
+      id,
+      fieldId: firstField?.id ?? '',
+      operator: 'equals',
+      value: '',
+      action: 'show',
+      targetId: firstField?.id ?? '',
+    };
+    onChange({ rules: [...logic.rules, rule] });
+  };
+
+  return (
+    <section className="bf-logic" aria-label="Conditional logic">
+      <div className="bf-panel-heading-group">
+        <h2 className="bf-panel-heading">Conditional logic</h2>
+        <button type="button" className="bf-button-secondary" onClick={addRule}>
+          Add rule
+        </button>
+      </div>
+      {logic.rules.length === 0 && <p>No logic yet. Add a rule to start orchestrating conditional behaviors.</p>}
+      <ol className="bf-logic__list">
+        {logic.rules.map((rule, index) => (
+          <li key={rule.id} className="bf-logic__rule">
+            <div className="bf-logic__row">
+              <label>
+                When
+                <select
+                  value={rule.fieldId}
+                  onChange={(event) => updateRule({ ...rule, fieldId: event.target.value }, index)}
+                >
+                  {flatFields.map((field) => (
+                    <option key={field.id} value={field.id}>
+                      {field.label || field.id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Operator
+                <select
+                  value={rule.operator}
+                  onChange={(event) => updateRule({ ...rule, operator: event.target.value as LogicRule['operator'] }, index)}
+                >
+                  {OPERATORS.map((operator) => (
+                    <option key={operator.value} value={operator.value}>
+                      {operator.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Value
+                <input value={rule.value} onChange={(event) => updateRule({ ...rule, value: event.target.value }, index)} />
+              </label>
+            </div>
+            <div className="bf-logic__row">
+              <label>
+                Then
+                <select
+                  value={rule.action}
+                  onChange={(event) => updateRule({ ...rule, action: event.target.value as LogicRule['action'] }, index)}
+                >
+                  {ACTIONS.map((action) => (
+                    <option key={action.value} value={action.value}>
+                      {action.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Target field
+                <select
+                  value={rule.targetId}
+                  onChange={(event) => updateRule({ ...rule, targetId: event.target.value }, index)}
+                >
+                  {flatFields.map((field) => (
+                    <option key={field.id} value={field.id}>
+                      {field.label || field.id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button type="button" className="bf-button-danger" onClick={() => removeRule(index)}>
+                Remove
+              </button>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/wp-betterforms/src/admin/components/StylerPane.tsx
+++ b/wp-betterforms/src/admin/components/StylerPane.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { StylerPreset, StylerTokens } from '../types';
+
+const PRESET_MAP: Record<StylerPreset, Record<string, string>> = {
+  minimal: {
+    '--bf-control-border': '1px solid rgba(148, 163, 184, 0.5)',
+    '--bf-control-padding': '0.625rem 0.75rem',
+    '--bf-control-radius': '0.75rem',
+    '--bf-control-bg': 'rgba(255, 255, 255, 0.9)',
+    '--bf-label-weight': '600',
+  },
+  outlined: {
+    '--bf-control-border': '2px solid rgba(37, 99, 235, 0.4)',
+    '--bf-control-padding': '0.75rem 1rem',
+    '--bf-control-radius': '0.75rem',
+    '--bf-control-bg': 'white',
+    '--bf-label-weight': '500',
+  },
+  filled: {
+    '--bf-control-border': '1px solid transparent',
+    '--bf-control-padding': '0.75rem 1rem',
+    '--bf-control-radius': '0.75rem',
+    '--bf-control-bg': 'rgba(59, 130, 246, 0.12)',
+    '--bf-label-weight': '600',
+  },
+  underline: {
+    '--bf-control-border': '0 0 2px 0 rgba(148, 163, 184, 0.8)',
+    '--bf-control-padding': '0.5rem 0',
+    '--bf-control-radius': '0',
+    '--bf-control-bg': 'transparent',
+    '--bf-label-weight': '500',
+  },
+  compact: {
+    '--bf-control-border': '1px solid rgba(148, 163, 184, 0.3)',
+    '--bf-control-padding': '0.25rem 0.5rem',
+    '--bf-control-radius': '0.5rem',
+    '--bf-control-bg': 'white',
+    '--bf-label-weight': '500',
+  },
+  spacious: {
+    '--bf-control-border': '1px solid rgba(37, 99, 235, 0.25)',
+    '--bf-control-padding': '1rem 1.25rem',
+    '--bf-control-radius': '1rem',
+    '--bf-control-bg': 'rgba(37, 99, 235, 0.05)',
+    '--bf-label-weight': '600',
+  },
+  'dark-auto': {
+    '--bf-control-border': '1px solid rgba(148, 163, 184, 0.4)',
+    '--bf-control-padding': '0.75rem 1rem',
+    '--bf-control-radius': '0.75rem',
+    '--bf-control-bg': 'rgba(15, 23, 42, 0.4)',
+    '--bf-label-weight': '600',
+    '--bf-surface-bg': 'rgba(15, 23, 42, 0.75)',
+    '--bf-surface-color': 'rgba(248, 250, 252, 1)',
+  },
+};
+
+interface StylerPaneProps {
+  styles: StylerTokens;
+  onChange: (styles: StylerTokens) => void;
+}
+
+export function StylerPane({ styles, onChange }: StylerPaneProps) {
+  const [isImporting, setIsImporting] = useState(false);
+  const [importText, setImportText] = useState('');
+
+  const presetOptions = useMemo(() => Object.keys(PRESET_MAP) as StylerPreset[], []);
+  const presetTokens = useMemo(() => PRESET_MAP[styles.preset], [styles.preset]);
+  const mergedTokens = useMemo(() => ({ ...presetTokens, ...styles.global, ...styles.form }), [presetTokens, styles.form, styles.global]);
+
+  const updatePreset = (preset: StylerPreset) => {
+    onChange({ ...styles, preset });
+  };
+
+  const updateToken = (scope: 'global' | 'form', key: string, value: string) => {
+    onChange({ ...styles, [scope]: { ...styles[scope], [key]: value } });
+  };
+
+  const removeToken = (scope: 'global' | 'form', key: string) => {
+    const next = { ...styles[scope] };
+    delete next[key];
+    onChange({ ...styles, [scope]: next });
+  };
+
+  const exportJson = () => {
+    const payload = JSON.stringify(styles, null, 2);
+    navigator.clipboard?.writeText(payload).catch(() => {
+      setIsImporting(true);
+      setImportText(payload);
+    });
+  };
+
+  const applyImport = () => {
+    try {
+      const parsed = JSON.parse(importText) as StylerTokens;
+      if (!parsed || typeof parsed !== 'object') {
+        return;
+      }
+      onChange(parsed);
+      setIsImporting(false);
+      setImportText('');
+    } catch (error) {
+      console.error('Invalid style JSON', error);
+    }
+  };
+
+  const previewStyle = useMemo(() => {
+    const cssVars = Object.entries(mergedTokens).reduce<Record<string, string>>((acc, [key, value]) => {
+      if (!key.startsWith('--')) {
+        acc[`--${key}`] = value;
+        return acc;
+      }
+      acc[key] = value;
+      return acc;
+    }, {});
+
+    return cssVars;
+  }, [mergedTokens]);
+
+  return (
+    <section className="bf-styler" aria-label="Visual styler">
+      <div className="bf-panel-heading-group">
+        <h2 className="bf-panel-heading">Visual styler</h2>
+        <div className="bf-styler__actions">
+          <button type="button" className="bf-button-secondary" onClick={exportJson}>
+            Export JSON
+          </button>
+          <button type="button" className="bf-button-secondary" onClick={() => setIsImporting((value) => !value)}>
+            {isImporting ? 'Cancel' : 'Import JSON'}
+          </button>
+        </div>
+      </div>
+      <label className="bf-styler__preset">
+        Preset
+        <select value={styles.preset} onChange={(event) => updatePreset(event.target.value as StylerPreset)}>
+          {presetOptions.map((preset) => (
+            <option key={preset} value={preset}>
+              {preset.replace('-', ' ')}
+            </option>
+          ))}
+        </select>
+      </label>
+      {isImporting && (
+        <div className="bf-styler__import">
+          <textarea
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+            placeholder="Paste style JSON"
+          />
+          <button type="button" className="bf-button" onClick={applyImport}>
+            Apply styles
+          </button>
+        </div>
+      )}
+      <div className="bf-styler__tokens">
+        <TokenTable title="Global tokens" tokens={styles.global} preset={presetTokens} onChange={(key, value) => updateToken('global', key, value)} onRemove={(key) => removeToken('global', key)} />
+        <TokenTable title="Form overrides" tokens={styles.form} preset={presetTokens} onChange={(key, value) => updateToken('form', key, value)} onRemove={(key) => removeToken('form', key)} />
+      </div>
+      <div className="bf-styler__preview" style={previewStyle as CSSProperties}>
+        <div className="bf-styler__preview-surface">
+          <h3>Preview</h3>
+          <label>
+            <span>Name</span>
+            <input type="text" placeholder="Ada Lovelace" style={{ padding: 'var(--bf-control-padding)', borderRadius: 'var(--bf-control-radius)', border: 'var(--bf-control-border)', background: 'var(--bf-control-bg)', fontWeight: 'var(--bf-label-weight)' }} />
+          </label>
+          <label>
+            <span>Email</span>
+            <input type="email" placeholder="ada@example.com" style={{ padding: 'var(--bf-control-padding)', borderRadius: 'var(--bf-control-radius)', border: 'var(--bf-control-border)', background: 'var(--bf-control-bg)', fontWeight: 'var(--bf-label-weight)' }} />
+          </label>
+          <label>
+            <span>Message</span>
+            <textarea placeholder="Share a note" style={{ padding: 'var(--bf-control-padding)', borderRadius: 'var(--bf-control-radius)', border: 'var(--bf-control-border)', background: 'var(--bf-control-bg)', fontWeight: 'var(--bf-label-weight)' }} />
+          </label>
+          <button type="button" className="bf-button">Submit</button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface TokenTableProps {
+  title: string;
+  tokens: Record<string, string>;
+  preset: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+  onRemove: (key: string) => void;
+}
+
+function TokenTable({ title, tokens, preset, onChange, onRemove }: TokenTableProps) {
+  const tokenEntries = useMemo(() => Object.entries({ ...preset, ...tokens }), [preset, tokens]);
+
+  return (
+    <div className="bf-token-table">
+      <h3>{title}</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Value</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tokenEntries.map(([key, value]) => (
+            <tr key={key}>
+              <td>{key}</td>
+              <td>
+                <input value={tokens[key] ?? value} onChange={(event) => onChange(key, event.target.value)} />
+              </td>
+              <td>
+                {tokens[key] && (
+                  <button type="button" className="bf-button-danger" onClick={() => onRemove(key)}>
+                    Reset
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/wp-betterforms/src/admin/hooks/useForms.ts
+++ b/wp-betterforms/src/admin/hooks/useForms.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { FormResponse, FormSummary } from '../types';
+
+const config = (window as any).wpBetterFormsConfig ?? {};
+const apiBase: string = config.restBase ?? '';
+const nonce: string = config.nonce ?? '';
+
+export function useForms() {
+  const [forms, setForms] = useState<FormSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchForms = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(apiBase, {
+        headers: {
+          'X-WP-Nonce': nonce,
+        },
+      });
+      if (!response.ok) {
+        throw new Error('Unable to load forms');
+      }
+      const data = (await response.json()) as FormResponse;
+      setForms(data.forms);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchForms().catch((error) => {
+      console.error('Failed to fetch forms', error);
+    });
+  }, [fetchForms]);
+
+  return { forms, loading, error, refresh: fetchForms };
+}
+
+export function getNonce() {
+  return nonce;
+}
+
+export function getApiBase() {
+  return apiBase;
+}

--- a/wp-betterforms/src/admin/main.tsx
+++ b/wp-betterforms/src/admin/main.tsx
@@ -1,171 +1,328 @@
 import './styles.css';
 import { createRoot } from 'react-dom/client';
-import { StrictMode, useEffect, useState } from 'react';
+import { StrictMode, useCallback, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { FormList } from './components/FormList';
+import type { BuilderForm, FormField, FormSchema, SingleFormResponse } from './types';
+import { BuilderCanvas } from './components/BuilderCanvas';
+import { FieldPalette } from './components/FieldPalette';
+import { FieldInspector } from './components/FieldInspector';
+import { LogicEditor } from './components/LogicEditor';
+import { StylerPane } from './components/StylerPane';
+import { IntegrationsPanel } from './components/IntegrationsPanel';
+import { getApiBase, getNonce } from './hooks/useForms';
+import { createField, findField, removeField, updateField } from './utils/schema';
 
-type FormSummary = {
-id: number;
-title: string;
-slug: string;
-status: string;
-updated_at: string;
+const rootEl = document.getElementById('wp-betterforms-admin');
+
+const SCHEMA_TEMPLATE: FormSchema = {
+  fields: [],
+  logic: { rules: [] },
+  integrations: {
+    emailNotifications: {
+      enabled: true,
+      recipients: '',
+    },
+    webhook: {
+      enabled: false,
+      url: '',
+    },
+  },
 };
 
-type FormResponse = {
-forms: FormSummary[];
-};
-
-type BuilderForm = {
-id?: number;
-title: string;
-slug: string;
-schema: Record<string, unknown>;
-styles: Record<string, unknown>;
-status: string;
-};
-
-const apiBase = (window as any).wpBetterFormsConfig?.restBase ?? '';
-const nonce = (window as any).wpBetterFormsConfig?.nonce ?? '';
-
-function useForms() {
-const [forms, setForms] = useState<FormSummary[]>([]);
-const [loading, setLoading] = useState(false);
-const [error, setError] = useState<string | null>(null);
-
-const fetchForms = async () => {
-setLoading(true);
-try {
-const res = await fetch(apiBase, {
-headers: {
-'X-WP-Nonce': nonce,
-},
-});
-if (!res.ok) {
-throw new Error('Failed to fetch forms');
-}
-const data = (await res.json()) as FormResponse;
-setForms(data.forms);
-} catch (err) {
-setError((err as Error).message);
-} finally {
-setLoading(false);
-}
-};
-
-useEffect(() => {
-fetchForms();
-}, []);
-
-return { forms, loading, error, refresh: fetchForms };
+function createDefaultSchema(): FormSchema {
+  return {
+    fields: [],
+    logic: { rules: [] },
+    integrations: {
+      emailNotifications: { ...SCHEMA_TEMPLATE.integrations.emailNotifications },
+      webhook: { ...SCHEMA_TEMPLATE.integrations.webhook },
+    },
+  };
 }
 
-function FormList({ onCreate }: { onCreate: () => void }) {
-const { forms, loading, error, refresh } = useForms();
-
-return (
-<section className="bf-admin-panel">
-<header className="bf-admin-panel__header">
-<h1>WP Better Forms</h1>
-<button onClick={onCreate} className="bf-button">New form</button>
-</header>
-{loading && <p>Loading…</p>}
-{error && <p className="bf-error">{error}</p>}
-<ul className="bf-form-list">
-{forms.map((form) => (
-<li key={form.id}>
-<strong>{form.title}</strong>
-<span>{form.status}</span>
-<time dateTime={form.updated_at}>{form.updated_at}</time>
-</li>
-))}
-</ul>
-</section>
-);
+function createDefaultStyles() {
+  return {
+    preset: 'minimal' as const,
+    global: {},
+    form: {},
+  };
 }
 
-function Builder({ form, onSave }: { form: BuilderForm; onSave: (form: BuilderForm) => void }) {
-const [draft, setDraft] = useState<BuilderForm>(form);
-const [saving, setSaving] = useState(false);
-const [message, setMessage] = useState<string | null>(null);
+function normalizeForm(form: BuilderForm): BuilderForm {
+  const defaults = createDefaultSchema();
+  const defaultStyles = createDefaultStyles();
+  const schema = form.schema ?? defaults;
+  const styles = form.styles ?? defaultStyles;
 
-const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-setDraft({ ...draft, [event.target.name]: event.target.value });
-};
-
-const save = async () => {
-setSaving(true);
-setMessage(null);
-try {
-const res = await fetch(apiBase, {
-method: 'POST',
-headers: {
-'Content-Type': 'application/json',
-'X-WP-Nonce': nonce,
-},
-body: JSON.stringify(draft),
-});
-if (!res.ok) {
-throw new Error('Unable to save form');
+  return {
+    ...form,
+    schema: {
+      ...defaults,
+      ...schema,
+      fields: Array.isArray(schema.fields) ? schema.fields : [],
+      logic: schema.logic ?? defaults.logic,
+      integrations: {
+        emailNotifications: {
+          ...defaults.integrations.emailNotifications,
+          ...(schema.integrations?.emailNotifications ?? {}),
+        },
+        webhook: {
+          ...defaults.integrations.webhook,
+          ...(schema.integrations?.webhook ?? {}),
+        },
+      },
+    },
+    styles: {
+      ...defaultStyles,
+      ...styles,
+      global: styles.global ?? {},
+      form: styles.form ?? {},
+    },
+  };
 }
-const data = await res.json();
-onSave(data.form);
-setMessage('Form saved successfully.');
-} catch (err) {
-setMessage((err as Error).message);
-} finally {
-setSaving(false);
-}
-};
 
-return (
-<div className="bf-builder">
-<header>
-<input
-name="title"
-value={draft.title}
-onChange={handleChange}
-placeholder="Form title"
-aria-label="Form title"
-/>
-<textarea
-name="slug"
-value={draft.slug}
-onChange={handleChange}
-placeholder="Slug"
-aria-label="Form slug"
-/>
-</header>
-<div className="bf-builder__actions">
-<button className="bf-button" disabled={saving} onClick={save}>
-{saving ? 'Saving…' : 'Save form'}
-</button>
-</div>
-{message && <p role="status">{message}</p>}
-<section className="bf-builder__placeholder" aria-live="polite">
-<p>Drag and drop fields, configure conditional logic, and design styles here. This lightweight shell ensures the PHP integration works end-to-end.</p>
-</section>
-</div>
-);
+function createNewForm(): BuilderForm {
+  const slug = `form-${Date.now()}`;
+  return normalizeForm({
+    title: 'Untitled form',
+    slug,
+    status: 'draft',
+    schema: createDefaultSchema(),
+    styles: createDefaultStyles(),
+  });
 }
 
 function App() {
-const [currentForm, setCurrentForm] = useState<BuilderForm | null>(null);
+  const [currentForm, setCurrentForm] = useState<BuilderForm | null>(null);
+  const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [loadingForm, setLoadingForm] = useState(false);
 
-return (
-<main className="bf-admin">
-{currentForm ? (
-<Builder form={currentForm} onSave={(form) => setCurrentForm(form)} />
-) : (
-<FormList onCreate={() => setCurrentForm({ title: 'Untitled form', slug: 'untitled-form', schema: { fields: [] }, styles: { tokens: {} }, status: 'draft' })} />
-)}
-</main>
-);
+  const nonce = getNonce();
+  const apiBase = getApiBase();
+
+  const selectedField = useMemo(() => {
+    if (!currentForm || !selectedFieldId) {
+      return null;
+    }
+    return findField(currentForm.schema.fields, selectedFieldId);
+  }, [currentForm, selectedFieldId]);
+
+  const updateForm = useCallback(
+    (updater: (form: BuilderForm) => BuilderForm) => {
+      setCurrentForm((form) => (form ? updater(form) : form));
+    },
+    [],
+  );
+
+  const startNewForm = () => {
+    setSelectedFieldId(null);
+    setStatusMessage(null);
+    setCurrentForm(createNewForm());
+  };
+
+  const loadForm = async (formId: number) => {
+    setLoadingForm(true);
+    setStatusMessage(null);
+    try {
+      const response = await fetch(`${apiBase}/${formId}`, {
+        headers: {
+          'X-WP-Nonce': nonce,
+        },
+      });
+      if (!response.ok) {
+        throw new Error('Unable to load form');
+      }
+      const data = (await response.json()) as SingleFormResponse;
+      setCurrentForm(normalizeForm(data.form));
+      setSelectedFieldId(null);
+    } catch (error) {
+      console.error('Failed to load form', error);
+      setStatusMessage('Unable to load the requested form.');
+    } finally {
+      setLoadingForm(false);
+    }
+  };
+
+  const handleFieldCreate = (field: FormField) => {
+    setSelectedFieldId(field.id);
+  };
+
+  const handleFieldChange = (fields: FormField[]) => {
+    updateForm((form) => ({
+      ...form,
+      schema: {
+        ...form.schema,
+        fields,
+      },
+    }));
+  };
+
+  const handleInspectorChange = (fieldId: string, updates: Partial<FormField>) => {
+    updateForm((form) => ({
+      ...form,
+      schema: {
+        ...form.schema,
+        fields: updateField(form.schema.fields, fieldId, (field) => ({
+          ...field,
+          ...updates,
+        })),
+      },
+    }));
+  };
+
+  const handleFieldDelete = (fieldId: string) => {
+    updateForm((form) => ({
+      ...form,
+      schema: {
+        ...form.schema,
+        fields: removeField(form.schema.fields, fieldId),
+      },
+    }));
+    setSelectedFieldId(null);
+  };
+
+  const handleLogicChange = (logic: BuilderForm['schema']['logic']) => {
+    updateForm((form) => ({
+      ...form,
+      schema: {
+        ...form.schema,
+        logic,
+      },
+    }));
+  };
+
+  const handleIntegrationsChange = (integrations: BuilderForm['schema']['integrations']) => {
+    updateForm((form) => ({
+      ...form,
+      schema: {
+        ...form.schema,
+        integrations,
+      },
+    }));
+  };
+
+  const handleStyleChange = (styles: BuilderForm['styles']) => {
+    updateForm((form) => ({
+      ...form,
+      styles,
+    }));
+  };
+
+  const handleMetaChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    updateForm((form) => ({
+      ...form,
+      [name]: value,
+    }));
+  };
+
+  const saveForm = async () => {
+    if (!currentForm) {
+      return;
+    }
+    setSaving(true);
+    setStatusMessage(null);
+    try {
+      const response = await fetch(apiBase, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-WP-Nonce': nonce,
+        },
+        body: JSON.stringify(currentForm),
+      });
+      if (!response.ok) {
+        throw new Error('Unable to save form');
+      }
+      const data = (await response.json()) as SingleFormResponse;
+      setCurrentForm(normalizeForm(data.form));
+      setStatusMessage('Form saved successfully.');
+    } catch (error) {
+      console.error('Failed to save form', error);
+      setStatusMessage('Unable to save form.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!rootEl) {
+    return null;
+  }
+
+  return (
+    <main className="bf-admin" aria-busy={saving}>
+      {!currentForm ? (
+        <FormList onCreate={startNewForm} onOpen={loadForm} />
+      ) : (
+        <div className="bf-builder" role="region" aria-live="polite">
+          <header className="bf-builder__header">
+            <div className="bf-builder__meta">
+              <label>
+                <span className="bf-label">Form title</span>
+                <input name="title" value={currentForm.title} onChange={handleMetaChange} />
+              </label>
+              <label>
+                <span className="bf-label">Slug</span>
+                <input name="slug" value={currentForm.slug} onChange={handleMetaChange} />
+              </label>
+            </div>
+            <div className="bf-builder__actions">
+              <button type="button" className="bf-button-secondary" onClick={() => setCurrentForm(null)}>
+                Back to forms
+              </button>
+              <button type="button" className="bf-button" onClick={saveForm} disabled={saving}>
+                {saving ? 'Saving…' : 'Save form'}
+              </button>
+            </div>
+          </header>
+          {statusMessage && (
+            <p className="bf-status" role="status">
+              {statusMessage}
+            </p>
+          )}
+          {loadingForm ? (
+            <p>Loading form…</p>
+          ) : (
+            <div className="bf-builder__layout">
+              <FieldPalette
+                onAdd={(type) => {
+                  const field = createField(type);
+                  handleFieldChange([...currentForm.schema.fields, field]);
+                  handleFieldCreate(field);
+                }}
+              />
+              <BuilderCanvas
+                fields={currentForm.schema.fields}
+                selectedFieldId={selectedFieldId}
+                onChange={handleFieldChange}
+                onSelect={setSelectedFieldId}
+                onCreate={handleFieldCreate}
+              />
+              <FieldInspector field={selectedField} onChange={handleInspectorChange} onDelete={handleFieldDelete} />
+            </div>
+          )}
+          <div className="bf-builder__secondary">
+            <LogicEditor logic={currentForm.schema.logic} fields={currentForm.schema.fields} onChange={handleLogicChange} />
+            <IntegrationsPanel integrations={currentForm.schema.integrations} onChange={handleIntegrationsChange} />
+            <StylerPane styles={currentForm.styles} onChange={handleStyleChange} />
+          </div>
+        </div>
+      )}
+      <div className="sr-only" aria-live="polite">
+        {statusMessage}
+      </div>
+    </main>
+  );
 }
 
-const rootElement = document.getElementById('wp-betterforms-admin');
-if (rootElement) {
-createRoot(rootElement).render(
-<StrictMode>
-<App />
-</StrictMode>
-);
+if (rootEl) {
+  const root = createRoot(rootEl);
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
 }

--- a/wp-betterforms/src/admin/styles.css
+++ b/wp-betterforms/src/admin/styles.css
@@ -1,64 +1,493 @@
 :root {
-color-scheme: light dark;
+  color-scheme: light dark;
+  --bf-surface: #ffffff;
+  --bf-surface-alt: rgba(15, 23, 42, 0.04);
+  --bf-border: rgba(15, 23, 42, 0.12);
+  --bf-text: #0f172a;
+  --bf-text-muted: rgba(15, 23, 42, 0.7);
+  --bf-radius: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--wp--preset--font-family--system-font, system-ui, sans-serif);
+  color: var(--bf-text);
+  background: #f8fafc;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .bf-admin {
-padding: 24px;
-font-family: var(--wp--preset--font-family--system-font, system-ui, sans-serif);
+  padding: 24px;
+  min-height: 100vh;
 }
 
-.bf-admin-panel__header {
-display: flex;
-justify-content: space-between;
-align-items: center;
-margin-bottom: 1rem;
+.bf-button,
+.bf-button-secondary,
+.bf-button-danger {
+  border-radius: 999px;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.bf-button:hover,
+.bf-button-secondary:hover,
+.bf-button-danger:hover {
+  transform: translateY(-1px);
 }
 
 .bf-button {
-background-color: #2563eb;
-color: #fff;
-padding: 0.5rem 1rem;
-border-radius: 999px;
-border: none;
-cursor: pointer;
+  background: #2563eb;
+  color: #fff;
+}
+
+.bf-button-secondary {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+}
+
+.bf-button-danger {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.bf-admin-panel {
+  background: var(--bf-surface);
+  border-radius: var(--bf-radius);
+  padding: 2rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.bf-admin-panel__header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.bf-admin-panel__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.bf-admin-panel__subtitle {
+  color: var(--bf-text-muted);
+  margin: 0.5rem 0 0;
 }
 
 .bf-form-list {
-list-style: none;
-padding: 0;
-margin: 0;
-display: grid;
-gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .bf-form-list li {
-padding: 1rem;
-border: 1px solid rgba(15, 23, 42, 0.1);
-border-radius: 12px;
-display: flex;
-justify-content: space-between;
-align-items: baseline;
-gap: 1rem;
-background: #fff;
+  background: var(--bf-surface-alt);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 }
 
-.bf-builder header {
-display: grid;
-gap: 0.5rem;
-margin-bottom: 1rem;
+.bf-form-list__title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
 }
 
-.bf-builder__actions {
-margin-bottom: 1rem;
+.bf-form-list__meta {
+  margin: 0;
+  color: var(--bf-text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
-.bf-builder__placeholder {
-border: 2px dashed rgba(37, 99, 235, 0.3);
-border-radius: 12px;
-padding: 2rem;
-background: rgba(37, 99, 235, 0.04);
+.bf-builder {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.bf-builder__header {
+  background: var(--bf-surface);
+  padding: 1.5rem;
+  border-radius: var(--bf-radius);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.bf-builder__meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.bf-builder__meta label {
+  display: grid;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+.bf-builder__meta input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--bf-border);
+  min-width: 220px;
+}
+
+.bf-builder__layout {
+  display: grid;
+  grid-template-columns: minmax(200px, 240px) 1fr minmax(220px, 280px);
+  gap: 1.5rem;
+}
+
+.bf-palette,
+.bf-inspector,
+.bf-canvas {
+  background: var(--bf-surface);
+  border-radius: var(--bf-radius);
+  padding: 1rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.bf-panel-heading {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.bf-panel-heading-group {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.bf-palette__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-palette__item {
+  width: 100%;
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 12px;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  color: #1d4ed8;
+  display: grid;
+  text-align: left;
+  gap: 0.25rem;
+  padding: 0.75rem;
+}
+
+.bf-palette__item:focus {
+  outline: 2px solid #1d4ed8;
+}
+
+.bf-palette__item-label {
+  font-weight: 600;
+}
+
+.bf-palette__item-description {
+  font-size: 0.85rem;
+  color: var(--bf-text-muted);
+}
+
+.bf-canvas {
+  min-height: 480px;
+  position: relative;
+}
+
+.bf-canvas__list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-canvas__dropzone {
+  border: 2px dashed rgba(37, 99, 235, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem;
+  text-align: center;
+  color: var(--bf-text-muted);
+}
+
+.bf-field-node {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.bf-field-node.is-selected .bf-field-node__body {
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.bf-field-node__body {
+  border: 1px solid var(--bf-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: #fff;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-field-node__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bf-field-node__drag {
+  background: transparent;
+  border: none;
+  cursor: grab;
+  font-size: 1.25rem;
+}
+
+.bf-field-node__label {
+  background: rgba(37, 99, 235, 0.1);
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  cursor: pointer;
+}
+
+.bf-field-node__type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #1d4ed8;
+}
+
+.bf-field-node__name {
+  font-weight: 600;
+}
+
+.bf-field-node__children {
+  border-top: 1px dashed rgba(37, 99, 235, 0.2);
+  padding-top: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-drop-target {
+  min-height: 12px;
+  border-radius: 6px;
+}
+
+.bf-drop-target.is-inner {
+  border: 2px dashed rgba(37, 99, 235, 0.35);
+  padding: 0.75rem;
+  text-align: center;
+  color: var(--bf-text-muted);
+}
+
+.bf-inspector {
+  align-self: start;
+}
+
+.bf-inspector label,
+.bf-inspector textarea,
+.bf-inspector input {
+  width: 100%;
+}
+
+.bf-inspector label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.bf-inspector input,
+.bf-inspector textarea {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--bf-border);
+}
+
+.bf-inspector textarea {
+  min-height: 96px;
+}
+
+.bf-inspector__options ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.bf-field-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bf-builder__secondary {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.bf-logic,
+.bf-integrations,
+.bf-styler {
+  background: var(--bf-surface);
+  border-radius: var(--bf-radius);
+  padding: 1.5rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.bf-logic__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.bf-logic__rule {
+  border: 1px solid var(--bf-border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-logic__row {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.bf-logic__row label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.bf-logic select,
+.bf-logic input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--bf-border);
+}
+
+.bf-integrations fieldset {
+  border: 1px solid var(--bf-border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bf-integrations legend {
+  font-weight: 700;
+}
+
+.bf-styler__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.bf-styler__preset {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.bf-styler select,
+.bf-styler textarea,
+.bf-styler input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--bf-border);
+}
+
+.bf-styler__import textarea {
+  min-height: 120px;
+}
+
+.bf-styler__tokens {
+  display: grid;
+  gap: 1rem;
+}
+
+.bf-token-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.bf-token-table th,
+.bf-token-table td {
+  text-align: left;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--bf-border);
+}
+
+.bf-styler__preview {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.bf-styler__preview-surface {
+  background: var(--bf-surface-bg, var(--bf-surface));
+  color: var(--bf-surface-color, var(--bf-text));
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.bf-status {
+  margin: 0;
+  font-weight: 600;
+  color: #065f46;
 }
 
 .bf-error {
-color: #b91c1c;
+  color: #b91c1c;
+}
+
+@media (max-width: 960px) {
+  .bf-builder__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .bf-builder__secondary {
+    grid-template-columns: 1fr;
+  }
 }

--- a/wp-betterforms/src/admin/types.ts
+++ b/wp-betterforms/src/admin/types.ts
@@ -1,0 +1,98 @@
+export type FieldType =
+  | 'text'
+  | 'textarea'
+  | 'email'
+  | 'number'
+  | 'checkbox'
+  | 'select'
+  | 'repeater';
+
+export type FieldOption = {
+  id: string;
+  label: string;
+};
+
+export interface FormField {
+  id: string;
+  type: FieldType;
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  helpText?: string;
+  options?: FieldOption[];
+  children?: FormField[];
+}
+
+export interface IntegrationSettings {
+  emailNotifications: {
+    enabled: boolean;
+    recipients: string;
+  };
+  webhook: {
+    enabled: boolean;
+    url: string;
+  };
+}
+
+export type LogicOperator = 'equals' | 'not_equals' | 'contains' | 'greater_than' | 'less_than';
+
+export type LogicActionType = 'show' | 'hide' | 'enable' | 'disable';
+
+export interface LogicRule {
+  id: string;
+  fieldId: string;
+  operator: LogicOperator;
+  value: string;
+  action: LogicActionType;
+  targetId: string;
+}
+
+export interface FormLogic {
+  rules: LogicRule[];
+}
+
+export interface StylerTokens {
+  preset: StylerPreset;
+  global: Record<string, string>;
+  form: Record<string, string>;
+}
+
+export type StylerPreset =
+  | 'minimal'
+  | 'outlined'
+  | 'filled'
+  | 'underline'
+  | 'compact'
+  | 'spacious'
+  | 'dark-auto';
+
+export interface FormSchema {
+  fields: FormField[];
+  logic: FormLogic;
+  integrations: IntegrationSettings;
+}
+
+export interface BuilderForm {
+  id?: number;
+  title: string;
+  slug: string;
+  status: string;
+  schema: FormSchema;
+  styles: StylerTokens;
+}
+
+export interface FormSummary {
+  id: number;
+  title: string;
+  slug: string;
+  status: string;
+  updated_at: string;
+}
+
+export interface FormResponse {
+  forms: FormSummary[];
+}
+
+export interface SingleFormResponse {
+  form: BuilderForm;
+}

--- a/wp-betterforms/src/admin/utils/schema.ts
+++ b/wp-betterforms/src/admin/utils/schema.ts
@@ -1,0 +1,165 @@
+import { FieldType, FormField } from '../types';
+
+export function createField(type: FieldType): FormField {
+  const base: FormField = {
+    id: crypto.randomUUID(),
+    type,
+    label: defaultLabel(type),
+    required: false,
+    placeholder: '',
+    helpText: '',
+  };
+
+  if (type === 'select' || type === 'checkbox') {
+    base.options = [
+      { id: crypto.randomUUID(), label: 'Option 1' },
+      { id: crypto.randomUUID(), label: 'Option 2' },
+    ];
+  }
+
+  if (type === 'repeater') {
+    base.children = [];
+  }
+
+  return base;
+}
+
+function defaultLabel(type: FieldType): string {
+  switch (type) {
+    case 'text':
+      return 'Text field';
+    case 'textarea':
+      return 'Paragraph';
+    case 'email':
+      return 'Email';
+    case 'number':
+      return 'Number';
+    case 'checkbox':
+      return 'Checkboxes';
+    case 'select':
+      return 'Dropdown';
+    case 'repeater':
+      return 'Repeater';
+    default:
+      return 'Field';
+  }
+}
+
+export function findField(fields: FormField[], fieldId: string): FormField | null {
+  for (const field of fields) {
+    if (field.id === fieldId) {
+      return field;
+    }
+
+    if (field.children) {
+      const nested = findField(field.children, fieldId);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function updateField(
+  fields: FormField[],
+  fieldId: string,
+  updater: (field: FormField) => FormField,
+): FormField[] {
+  return fields.map((field) => {
+    if (field.id === fieldId) {
+      return updater(field);
+    }
+
+    if (field.children) {
+      return {
+        ...field,
+        children: updateField(field.children, fieldId, updater),
+      };
+    }
+
+    return field;
+  });
+}
+
+export function removeField(fields: FormField[], fieldId: string): FormField[] {
+  return fields
+    .filter((field) => field.id !== fieldId)
+    .map((field) =>
+      field.children
+        ? {
+            ...field,
+            children: removeField(field.children, fieldId),
+          }
+        : field,
+    );
+}
+
+function insertField(
+  fields: FormField[],
+  field: FormField,
+  parentId: string | null,
+  index: number,
+): FormField[] {
+  if (!parentId) {
+    const clone = [...fields];
+    clone.splice(index, 0, field);
+    return clone;
+  }
+
+  return fields.map((existing) => {
+    if (existing.id === parentId) {
+      const children = existing.children ? [...existing.children] : [];
+      children.splice(index, 0, field);
+      return {
+        ...existing,
+        children,
+      };
+    }
+
+    if (existing.children) {
+      return {
+        ...existing,
+        children: insertField(existing.children, field, parentId, index),
+      };
+    }
+
+    return existing;
+  });
+}
+
+export type DropLocation = {
+  parentId: string | null;
+  index: number;
+};
+
+export function addFieldAt(
+  fields: FormField[],
+  field: FormField,
+  location: DropLocation,
+): FormField[] {
+  return insertField(fields, field, location.parentId, location.index);
+}
+
+export function moveField(
+  fields: FormField[],
+  fieldId: string,
+  location: DropLocation,
+): FormField[] {
+  const field = findField(fields, fieldId);
+  if (!field) {
+    return fields;
+  }
+
+  const without = removeField(fields, fieldId);
+  return insertField(without, field, location.parentId, location.index);
+}
+
+export function flattenFields(fields: FormField[]): FormField[] {
+  return fields.flatMap((field) =>
+    field.children && field.children.length
+      ? [field, ...flattenFields(field.children)]
+      : [field],
+  );
+}

--- a/wp-betterforms/tests/js/builder-schema.test.ts
+++ b/wp-betterforms/tests/js/builder-schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { addFieldAt, createField, findField, moveField, removeField } from '../../src/admin/utils/schema';
+
+describe('schema utilities', () => {
+  it('creates default repeater with nested children array', () => {
+    const repeater = createField('repeater');
+    expect(repeater.children).toEqual([]);
+  });
+
+  it('adds fields at root and nested locations', () => {
+    const repeater = createField('repeater');
+    let fields = addFieldAt([], repeater, { parentId: null, index: 0 });
+    const child = createField('text');
+    fields = addFieldAt(fields, child, { parentId: repeater.id, index: 0 });
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0].children).toHaveLength(1);
+    expect(fields[0].children?.[0].id).toBe(child.id);
+  });
+
+  it('moves a field between parents', () => {
+    const repeater = createField('repeater');
+    const text = createField('text');
+    const another = createField('email');
+
+    let fields = [repeater, text];
+    fields = addFieldAt(fields, another, { parentId: repeater.id, index: 0 });
+
+    fields = moveField(fields, text.id, { parentId: repeater.id, index: 1 });
+
+    const parent = findField(fields, repeater.id);
+    expect(parent?.children?.map((child) => child.id)).toEqual([another.id, text.id]);
+  });
+
+  it('removes fields recursively', () => {
+    const repeater = createField('repeater');
+    const child = createField('text');
+    let fields = addFieldAt([], repeater, { parentId: null, index: 0 });
+    fields = addFieldAt(fields, child, { parentId: repeater.id, index: 0 });
+
+    fields = removeField(fields, child.id);
+    expect(findField(fields, child.id)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the admin placeholder with a modular builder that normalizes form payloads, drives REST persistence, and wires focus/status management
- add drag-and-drop field canvas with repeater nesting, conditional logic, integrations controls, and a visual styler supporting presets and import/export
- refresh admin styling to support the new layout and accessibility affordances

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8ace6b66c8326ab9f3ffaa00dbd8f