### PR TITLE
Enhance validation, REST spam defenses, and queue monitoring

### DIFF
--- a/wp-betterforms/includes/class-admin-dashboard.php
+++ b/wp-betterforms/includes/class-admin-dashboard.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Dashboard widget for queue visibility.
+ */
+
+namespace WP_BetterForms\Admin;
+
+use WP_BetterForms\Rest\Rest_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Admin_Dashboard
+ */
+final class Admin_Dashboard {
+private static ?self $instance = null;
+private static bool $script_rendered = false;
+
+private function __construct() {
+add_action( 'wp_dashboard_setup', [ $this, 'register_widget' ] );
+}
+
+public static function get_instance(): self {
+if ( null === self::$instance ) {
+self::$instance = new self();
+}
+
+return self::$instance;
+}
+
+public function register_widget(): void {
+if ( ! current_user_can( 'manage_options' ) ) {
+return;
+}
+
+wp_add_dashboard_widget(
+'wp_betterforms_email_queue',
+__( 'Better Forms Email Queue', 'wp-betterforms' ),
+[ $this, 'render_widget' ]
+);
+}
+
+public function render_widget(): void {
+$failures = $this->get_failures();
+$rest_base = rest_url( Rest_Controller::NAMESPACE . '/email-queue/failures' );
+$resend   = rest_url( Rest_Controller::NAMESPACE . '/email-queue/__id__/resend' );
+$test     = rest_url( Rest_Controller::NAMESPACE . '/email-queue/test' );
+$nonce    = wp_create_nonce( 'wp_rest' );
+
+echo '<div id="bf-email-queue" class="bf-email-queue-widget" data-endpoint="' . esc_attr( $rest_base ) . '" data-resend="' . esc_attr( $resend ) . '" data-test="' . esc_attr( $test ) . '" data-nonce="' . esc_attr( $nonce ) . '">';
+
+echo '<p class="bf-email-queue-widget__intro">' . esc_html__( 'Monitor recent email queue failures and trigger retries directly from the dashboard.', 'wp-betterforms' ) . '</p>';
+
+echo '<div class="bf-email-queue-widget__actions">';
+echo '<label class="screen-reader-text" for="bf-email-test-address">' . esc_html__( 'Send test email to', 'wp-betterforms' ) . '</label>';
+echo '<input type="email" id="bf-email-test-address" placeholder="' . esc_attr( __( 'you@example.com', 'wp-betterforms' ) ) . '" />';
+echo '<button type="button" class="button bf-email-queue-widget__test" data-action="test">' . esc_html__( 'Send Test Email', 'wp-betterforms' ) . '</button>';
+echo '</div>';
+
+echo '<div class="bf-email-queue-widget__list" data-role="list">';
+if ( empty( $failures ) ) {
+    echo '<p class="bf-email-queue-widget__empty">' . esc_html__( 'No recent failures detected.', 'wp-betterforms' ) . '</p>';
+} else {
+    echo $this->render_failures_table( $failures );
+}
+echo '</div>';
+
+echo '</div>';
+
+if ( ! self::$script_rendered ) {
+self::$script_rendered = true;
+$this->render_widget_script();
+}
+}
+
+private function render_failures_table( array $failures ): string {
+$rows = array_map(
+static function ( array $failure ): string {
+$retry = '<button type="button" class="button-link" data-action="resend" data-id="' . esc_attr( (string) $failure['id'] ) . '">' . esc_html__( 'Retry', 'wp-betterforms' ) . '</button>';
+$details = esc_html( sprintf( '%s (%s)', $failure['to_email'], $failure['subject'] ) );
+$error = esc_html( $failure['last_error'] ?? __( 'Unknown error', 'wp-betterforms' ) );
+$attempts = esc_html( (string) $failure['attempts'] );
+$time = esc_html( $failure['updated_at'] );
+
+return '<tr><td>' . $details . '</td><td>' . $error . '</td><td>' . $attempts . '</td><td>' . $time . '</td><td>' . $retry . '</td></tr>';
+},
+$failures
+);
+
+$header = '<tr><th>' . esc_html__( 'Email', 'wp-betterforms' ) . '</th><th>' . esc_html__( 'Last Error', 'wp-betterforms' ) . '</th><th>' . esc_html__( 'Attempts', 'wp-betterforms' ) . '</th><th>' . esc_html__( 'Updated', 'wp-betterforms' ) . '</th><th>' . esc_html__( 'Actions', 'wp-betterforms' ) . '</th></tr>';
+
+return '<table class="widefat fixed"><thead>' . $header . '</thead><tbody>' . implode( '', $rows ) . '</tbody></table>';
+}
+
+private function render_widget_script(): void {
+$labels = [
+'empty'    => esc_js( __( 'No recent failures detected.', 'wp-betterforms' ) ),
+'retry'    => esc_js( __( 'Retry', 'wp-betterforms' ) ),
+'unknown'  => esc_js( __( 'Unknown error', 'wp-betterforms' ) ),
+'email'    => esc_js( __( 'Email', 'wp-betterforms' ) ),
+'error'    => esc_js( __( 'Last Error', 'wp-betterforms' ) ),
+'attempts' => esc_js( __( 'Attempts', 'wp-betterforms' ) ),
+'updated'  => esc_js( __( 'Updated', 'wp-betterforms' ) ),
+'actions'  => esc_js( __( 'Actions', 'wp-betterforms' ) ),
+'failed'   => esc_js( __( 'Unable to load failures.', 'wp-betterforms' ) ),
+];
+
+$labels_json = wp_json_encode( $labels );
+
+$script  = '<script>(function(){';
+$script .= 'const widget=document.getElementById("bf-email-queue");';
+$script .= 'if(!widget){return;}';
+$script .= 'const listEl=widget.querySelector("[data-role=\\"list\\"]");';
+$script .= 'const nonce=widget.dataset.nonce;';
+$script .= 'const endpoints={list:widget.dataset.endpoint,resend:widget.dataset.resend,test:widget.dataset.test};';
+$script .= 'const labels=' . $labels_json . ';';
+$script .= 'const renderEmpty=function(){listEl.innerHTML="<p class=\\"bf-email-queue-widget__empty\\">"+labels.empty+"</p>";};';
+$script .= 'const fetchFailures=function(){fetch(endpoints.list,{headers:{"X-WP-Nonce":nonce}})';
+$script .= '.then(function(response){return response.json();})';
+$script .= '.then(function(payload){if(!payload||!Array.isArray(payload.failures)||!payload.failures.length){renderEmpty();return;}';
+$script .= 'const rows=payload.failures.map(function(item){';
+$script .= 'const retry="<button type=\\"button\\" class=\\"button-link\\" data-action=\\"resend\\" data-id=\\""+item.id+"\\">"+labels.retry+"</button>";';
+$script .= 'const lastError=item.last_error||labels.unknown;';
+$script .= 'return "<tr><td>"+item.to_email+" ("+item.subject+")</td><td>"+lastError+"</td><td>"+item.attempts+"</td><td>"+item.updated_at+"</td><td>"+retry+"</td></tr>";';
+$script .= '}).join("" );';
+$script .= 'listEl.innerHTML="<table class=\\"widefat fixed\\"><thead><tr><th>"+labels.email+"</th><th>"+labels.error+"</th><th>"+labels.attempts+"</th><th>"+labels.updated+"</th><th>"+labels.actions+"</th></tr></thead><tbody>"+rows+"</tbody></table>";';
+$script .= '})';
+$script .= '.catch(function(){listEl.innerHTML="<p class=\\"bf-email-queue-widget__empty\\">"+labels.failed+"</p>";});};';
+$script .= 'widget.addEventListener("click",function(event){const target=event.target.closest("button[data-action]");if(!target){return;}';
+$script .= 'if(target.dataset.action==="test"){const emailInput=widget.querySelector("#bf-email-test-address");const email=emailInput?emailInput.value:"";fetch(endpoints.test,{method:"POST",headers:{"Content-Type":"application/json","X-WP-Nonce":nonce},body:JSON.stringify({to:email})}).then(fetchFailures);return;}';
+$script .= 'if(target.dataset.action==="resend"){const queueId=target.dataset.id;if(!queueId){return;}const endpoint=endpoints.resend.replace("__id__",queueId);fetch(endpoint,{method:"POST",headers:{"X-WP-Nonce":nonce}}).then(fetchFailures);}});';
+$script .= 'fetchFailures();})();</script>';
+
+echo $script;
+}
+
+private function get_failures(): array {
+global $wpdb;
+
+$table = $wpdb->prefix . 'bf_email_queue';
+$rows  = $wpdb->get_results( "SELECT id, form_id, to_email, subject, last_error, attempts, updated_at FROM $table WHERE status = 'failed' ORDER BY updated_at DESC LIMIT 5", ARRAY_A );
+
+return array_map(
+static function ( array $row ): array {
+return [
+'id'         => (int) $row['id'],
+'form_id'    => (int) ( $row['form_id'] ?? 0 ),
+'to_email'   => $row['to_email'],
+'subject'    => $row['subject'],
+'last_error' => $row['last_error'],
+'attempts'   => (int) $row['attempts'],
+'updated_at' => $row['updated_at'],
+];
+},
+$rows
+);
+}
+}

--- a/wp-betterforms/includes/class-admin-notices.php
+++ b/wp-betterforms/includes/class-admin-notices.php
@@ -38,7 +38,14 @@ if ( $failures < 3 ) {
 return;
 }
 
-echo '<div class="notice notice-error"><p>' . esc_html__( 'WP Better Forms detected repeated email delivery issues in the last hour. Please review the email queue.', 'wp-betterforms' ) . '</p></div>';
+$dashboard_url = admin_url( 'index.php#bf-email-queue' );
+$message       = sprintf(
+/* translators: %s is the dashboard URL */
+__( 'WP Better Forms detected repeated email delivery issues in the last hour. Please review the <a href="%s">email queue dashboard</a>.', 'wp-betterforms' ),
+esc_url( $dashboard_url )
+);
+
+echo '<div class="notice notice-error"><p>' . wp_kses_post( $message ) . '</p></div>';
 }
 
 private function get_recent_failures(): int {

--- a/wp-betterforms/includes/class-plugin.php
+++ b/wp-betterforms/includes/class-plugin.php
@@ -7,6 +7,7 @@
 
 namespace WP_BetterForms;
 
+use WP_BetterForms\Admin\Admin_Dashboard;
 use WP_BetterForms\Admin\Admin_Notices;
 use WP_BetterForms\Rest\Rest_Controller;
 use WP_BetterForms\Rendering\Renderer;
@@ -68,6 +69,7 @@ add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets
 add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_assets' ] );
 
 Admin_Notices::get_instance();
+Admin_Dashboard::get_instance();
 Scheduler::get_instance();
 }
 

--- a/wp-betterforms/includes/class-render.php
+++ b/wp-betterforms/includes/class-render.php
@@ -70,12 +70,14 @@ $nonce = wp_create_nonce( 'wp_rest' );
 
 $fields_markup = array_map( [ self::class, 'render_field' ], $fields );
 
-$honeypot = '<div class="bf-hp" aria-hidden="true"><label>' . esc_html__( 'Leave this field empty', 'wp-betterforms' ) . '</label><input type="text" name="bf_hp" tabindex="-1" autocomplete="off" value="" /></div>';
+$honeypot       = '<div class="bf-hp" aria-hidden="true"><label>' . esc_html__( 'Leave this field empty', 'wp-betterforms' ) . '</label><input type="text" name="bf_hp" tabindex="-1" autocomplete="off" value="" /></div>';
+$timing_inputs  = '<input type="hidden" name="bf_rendered_at" value="' . esc_attr( (string) time() ) . '" />';
+$timing_inputs .= '<input type="hidden" name="bf_elapsed" value="" />';
 
 $markup  = $style_block;
 $markup .= '<form class="bf-form bf-form--' . esc_attr( $form_id ) . '" id="' . esc_attr( $wrapper_id ) . '" data-form-id="' . esc_attr( $form_id ) . '" data-nonce="' . esc_attr( $nonce ) . '">';
 $markup .= implode( '', $fields_markup );
-$markup .= $honeypot;
+$markup .= $honeypot . $timing_inputs;
 $markup .= '<div class="bf-actions"><button type="submit" class="bf-submit">' . esc_html__( 'Submit', 'wp-betterforms' ) . '</button></div>';
 $markup .= '<div class="bf-messages" aria-live="polite" role="status"></div>';
 $markup .= '</form>';

--- a/wp-betterforms/includes/class-rest.php
+++ b/wp-betterforms/includes/class-rest.php
@@ -12,6 +12,7 @@ use WP_BetterForms\Rendering\Renderer;
 use WP_BetterForms\Validation\Validator;
 use WP_BetterForms\Mailing\Mailer;
 use WP_BetterForms\DB\Migrations;
+use WP_BetterForms\Logging\Logger;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -84,6 +85,41 @@ self::NAMESPACE,
 ],
 ]
 );
+
+register_rest_route(
+self::NAMESPACE,
+'/email-queue/failures',
+[
+'methods'             => WP_REST_Server::READABLE,
+'callback'            => [ $this, 'list_email_failures' ],
+'permission_callback' => static fn(): bool => current_user_can( 'manage_options' ),
+]
+);
+
+register_rest_route(
+self::NAMESPACE,
+'/email-queue/(?P<queue_id>\d+)/resend',
+[
+'methods'             => WP_REST_Server::CREATABLE,
+'callback'            => [ $this, 'resend_email' ],
+'permission_callback' => static fn(): bool => current_user_can( 'manage_options' ),
+'args'                => [
+'queue_id' => [
+'validate_callback' => static fn( $param ): bool => is_numeric( $param ),
+],
+],
+]
+);
+
+register_rest_route(
+self::NAMESPACE,
+'/email-queue/test',
+[
+'methods'             => WP_REST_Server::CREATABLE,
+'callback'            => [ $this, 'send_test_email' ],
+'permission_callback' => static fn(): bool => current_user_can( 'manage_options' ),
+]
+);
 }
 
 public function list_forms( WP_REST_Request $request ): WP_REST_Response {
@@ -128,7 +164,29 @@ return new WP_Error( 'bf_form_not_found', __( 'Form not found.', 'wp-betterforms
 }
 
 $data       = $request->get_json_params();
-$validation = Validator::validate_submission( $form, is_array( $data ) ? $data : [] );
+$data       = is_array( $data ) ? $data : [];
+
+$honeypot_error = $this->check_honeypot( $data, $form, $request );
+if ( is_wp_error( $honeypot_error ) ) {
+return $honeypot_error;
+}
+
+$rate_limit = $this->enforce_rate_limit( $request, $form );
+if ( is_wp_error( $rate_limit ) ) {
+return $rate_limit;
+}
+
+$captcha = $this->verify_captcha( $data, $form, $request );
+if ( is_wp_error( $captcha ) ) {
+return $captcha;
+}
+
+$spam_check = $this->check_spam_filters( $data, $form, $request );
+if ( is_wp_error( $spam_check ) ) {
+return $spam_check;
+}
+
+$validation = Validator::validate_submission( $form, $data );
 
 if ( is_wp_error( $validation ) ) {
 return $validation;
@@ -145,5 +203,213 @@ return new WP_REST_Response(
 'message'  => __( 'Form submitted successfully.', 'wp-betterforms' ),
 ]
 );
+}
+
+public function list_email_failures(): WP_REST_Response {
+global $wpdb;
+
+$table = $wpdb->prefix . 'bf_email_queue';
+$rows  = $wpdb->get_results( "SELECT id, form_id, to_email, subject, attempts, last_error, updated_at FROM $table WHERE status = 'failed' ORDER BY updated_at DESC LIMIT 20", ARRAY_A );
+
+$failures = array_map(
+static function ( array $row ): array {
+return [
+'id'         => (int) $row['id'],
+'form_id'    => (int) $row['form_id'],
+'to_email'   => $row['to_email'],
+'subject'    => $row['subject'],
+'attempts'   => (int) $row['attempts'],
+'last_error' => $row['last_error'],
+'updated_at' => $row['updated_at'],
+];
+},
+$rows
+);
+
+return new WP_REST_Response( [ 'failures' => $failures ] );
+}
+
+public function resend_email( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+global $wpdb;
+
+$queue_id = (int) $request->get_param( 'queue_id' );
+$table    = $wpdb->prefix . 'bf_email_queue';
+$record   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE id = %d", $queue_id ), ARRAY_A );
+
+if ( ! $record ) {
+return new WP_Error( 'bf_queue_not_found', __( 'Queue item not found.', 'wp-betterforms' ), [ 'status' => 404 ] );
+}
+
+$wpdb->update(
+$table,
+[
+'status'     => 'pending',
+'updated_at' => current_time( 'mysql' ),
+'last_error' => null,
+],
+[
+'id' => $queue_id,
+]
+);
+
+Logger::log( 'email', 'warning', 'Email queue item requeued from dashboard.', [ 'queue_id' => $queue_id ], (int) ( $record['form_id'] ?? 0 ) );
+
+return new WP_REST_Response( [ 'success' => true ] );
+}
+
+public function send_test_email( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+$params = $request->get_json_params();
+$to     = sanitize_email( (string) ( $params['to'] ?? get_option( 'admin_email' ) ) );
+
+if ( ! is_email( $to ) ) {
+return new WP_Error( 'bf_invalid_email', __( 'Provide a valid email address for the test.', 'wp-betterforms' ), [ 'status' => 400 ] );
+}
+
+$subject = sanitize_text_field( $params['subject'] ?? __( 'WP Better Forms Test Email', 'wp-betterforms' ) );
+$body    = wp_kses_post( $params['body'] ?? __( 'This is a test email from WP Better Forms.', 'wp-betterforms' ) );
+
+Mailer::enqueue_email(
+[
+'form_id'   => 0,
+'entry_id'  => null,
+'to_email'  => $to,
+'subject'   => $subject,
+'body_html' => $body,
+]
+);
+
+Logger::log( 'email', 'info', 'Dashboard test email queued.', [ 'to' => $to ] );
+
+return new WP_REST_Response( [ 'success' => true ] );
+}
+
+private function check_honeypot( array $data, array $form, WP_REST_Request $request ): true|WP_Error {
+if ( ! empty( $data['bf_hp'] ) ) {
+Logger::log( 'spam', 'warning', 'Honeypot field triggered.', [ 'form_id' => $form['id'] ?? null ] );
+
+return new WP_Error( 'bf_honeypot', __( 'Spam protection triggered.', 'wp-betterforms' ), [ 'status' => 400 ] );
+}
+
+$elapsed_seconds = null;
+
+if ( isset( $data['bf_elapsed'] ) ) {
+$elapsed_seconds = max( 0, (float) $data['bf_elapsed'] );
+} elseif ( isset( $data['bf_rendered_at'] ) ) {
+$elapsed_seconds = max( 0, time() - (int) $data['bf_rendered_at'] );
+}
+
+$min_delay = (float) apply_filters( 'wp_betterforms/honeypot_min_time', 2.0, $form, $request );
+
+if ( null !== $elapsed_seconds && $elapsed_seconds < $min_delay ) {
+Logger::log(
+'spam',
+'warning',
+'Timed honeypot threshold not met.',
+[
+'form_id'  => $form['id'] ?? null,
+'elapsed'  => $elapsed_seconds,
+'required' => $min_delay,
+]
+);
+
+return new WP_Error( 'bf_fast_submission', __( 'Form submitted too quickly.', 'wp-betterforms' ), [ 'status' => 400 ] );
+}
+
+return true;
+}
+
+private function enforce_rate_limit( WP_REST_Request $request, array $form ): true|WP_Error {
+$ip = $this->get_client_ip( $request );
+
+if ( ! $ip ) {
+return true;
+}
+
+$window = (int) apply_filters( 'wp_betterforms/rate_limit_window', MINUTE_IN_SECONDS * 5, $form, $request );
+$limit  = (int) apply_filters( 'wp_betterforms/rate_limit_max', 10, $form, $request );
+$key    = 'bf_rl_' . md5( (string) ( $form['id'] ?? 0 ) . '|' . $ip );
+$count  = (int) get_transient( $key );
+
+if ( $count >= $limit ) {
+Logger::log( 'spam', 'warning', 'Rate limit exceeded for submission.', [ 'ip' => $ip, 'form_id' => $form['id'] ?? null ] );
+
+return new WP_Error( 'bf_rate_limited', __( 'Too many submissions. Please try again later.', 'wp-betterforms' ), [ 'status' => 429 ] );
+}
+
+set_transient( $key, $count + 1, $window );
+
+return true;
+}
+
+private function verify_captcha( array $data, array $form, WP_REST_Request $request ): true|WP_Error {
+$captcha_meta = $data['_captcha'] ?? [];
+$provider     = $captcha_meta['provider'] ?? $form['integrations']['captcha']['provider'] ?? null;
+$token        = $captcha_meta['token'] ?? null;
+
+if ( ! $provider || ! $token ) {
+return true;
+}
+
+$filter  = 'wp_betterforms/verify_' . strtolower( (string) $provider );
+$verified = apply_filters( $filter, null, $token, $request, $form, $data );
+
+if ( $verified instanceof WP_Error ) {
+Logger::log( 'spam', 'warning', 'Captcha validation failed with error.', [ 'form_id' => $form['id'] ?? null, 'provider' => $provider ] );
+
+return $verified;
+}
+
+if ( false === $verified ) {
+Logger::log( 'spam', 'warning', 'Captcha validation rejected submission.', [ 'form_id' => $form['id'] ?? null, 'provider' => $provider ] );
+
+return new WP_Error( 'bf_captcha_failed', __( 'Captcha validation failed. Please try again.', 'wp-betterforms' ), [ 'status' => 400 ] );
+}
+
+return true;
+}
+
+private function check_spam_filters( array $data, array $form, WP_REST_Request $request ): true|WP_Error {
+$akismet_payload = apply_filters(
+'wp_betterforms/akismet_payload',
+[
+'comment_content' => wp_json_encode( $data ),
+'user_ip'         => $this->get_client_ip( $request ),
+'user_agent'      => $_SERVER['HTTP_USER_AGENT'] ?? '',
+],
+$form,
+$data,
+$request
+);
+
+$spam_result = apply_filters( 'wp_betterforms/check_spam', null, $akismet_payload, $form, $data, $request );
+
+if ( $spam_result instanceof WP_Error ) {
+Logger::log( 'spam', 'warning', 'Spam filter blocked submission.', [ 'form_id' => $form['id'] ?? null ] );
+
+return $spam_result;
+}
+
+if ( true === $spam_result || 'spam' === $spam_result ) {
+Logger::log( 'spam', 'warning', 'Spam filter flagged submission.', [ 'form_id' => $form['id'] ?? null ] );
+
+return new WP_Error( 'bf_spam_detected', __( 'Submission was flagged as spam.', 'wp-betterforms' ), [ 'status' => 400 ] );
+}
+
+return true;
+}
+
+private function get_client_ip( WP_REST_Request $request ): ?string {
+$headers = [ 'X-Forwarded-For', 'CF-Connecting-IP', 'X-Real-IP' ];
+
+foreach ( $headers as $header ) {
+$value = $request->get_header( $header );
+if ( $value ) {
+$parts = explode( ',', $value );
+
+return trim( $parts[0] );
+}
+}
+
+return $_SERVER['REMOTE_ADDR'] ?? null;
 }
 }

--- a/wp-betterforms/includes/class-validator.php
+++ b/wp-betterforms/includes/class-validator.php
@@ -21,50 +21,404 @@ $schema = $form['schema'] ?? [];
 $errors = [];
 
 foreach ( $schema['fields'] ?? [] as $field ) {
-$key      = $field['key'] ?? '';
-$required = ! empty( $field['required'] );
-$type     = $field['type'] ?? 'text';
-
-$value = $data[ $key ] ?? null;
-
-if ( $required && ( null === $value || '' === $value ) ) {
-$errors[ $key ] = $field['label'] ?? __( 'This field is required.', 'wp-betterforms' );
-continue;
+self::validate_field( $errors, $field, $data, $form );
 }
 
-if ( null === $value || '' === $value ) {
-continue;
+$errors = apply_filters( 'wp_betterforms/validation_errors', $errors, $form, $data );
+
+if ( ! empty( $errors ) ) {
+return new WP_Error(
+'bf_validation_failed',
+__( 'Validation failed.', 'wp-betterforms' ),
+[
+'status' => 422,
+'errors' => $errors,
+]
+);
+}
+
+return true;
+}
+
+/**
+ * Validate an individual field, including repeater children.
+ */
+private static function validate_field( array &$errors, array $field, array $submission, array $form, string $path = '' ): void {
+$key      = $field['key'] ?? '';
+$type     = $field['type'] ?? 'text';
+$path     = $path ?: $key;
+$visible  = self::field_is_visible( $field, $submission );
+$required = ! empty( $field['required'] );
+
+if ( 'repeater' === $type ) {
+self::validate_repeater_field( $errors, $field, $submission, $form, $path, $visible );
+
+return;
+}
+
+$value = $submission[ $key ] ?? null;
+
+if ( ! $visible ) {
+return;
+}
+
+if ( $required && self::is_empty( $value ) ) {
+self::add_error(
+$errors,
+$path,
+'required',
+$field['label'] ?? __( 'This field is required.', 'wp-betterforms' )
+);
+
+return;
+}
+
+if ( self::is_empty( $value ) ) {
+return;
 }
 
 switch ( $type ) {
 case 'email':
 if ( ! is_email( $value ) ) {
-$errors[ $key ] = __( 'Enter a valid email address.', 'wp-betterforms' );
+self::add_error( $errors, $path, 'invalid_email', __( 'Enter a valid email address.', 'wp-betterforms' ) );
 }
 break;
 case 'number':
 if ( ! is_numeric( $value ) ) {
-$errors[ $key ] = __( 'Enter a valid number.', 'wp-betterforms' );
+self::add_error( $errors, $path, 'invalid_number', __( 'Enter a valid number.', 'wp-betterforms' ) );
 }
 break;
 case 'phone':
 if ( ! preg_match( '/^[0-9\-\+\s\(\)]+$/', (string) $value ) ) {
-$errors[ $key ] = __( 'Enter a valid phone number.', 'wp-betterforms' );
+self::add_error( $errors, $path, 'invalid_phone', __( 'Enter a valid phone number.', 'wp-betterforms' ) );
+}
+break;
+}
+
+self::validate_inventory( $errors, $field, $value, $submission, $form, $path );
+self::validate_calculation( $errors, $field, $value, $submission, $form, $path );
+self::validate_unique_id( $errors, $field, $value, $submission, $form, $path );
+
+$filtered_error = apply_filters( 'wp_betterforms/validate_field', null, $field, $value, $submission, $form, $path );
+
+if ( is_wp_error( $filtered_error ) ) {
+self::add_error( $errors, $path, $filtered_error->get_error_code(), $filtered_error->get_error_message(), $filtered_error->get_error_data() );
+} elseif ( is_array( $filtered_error ) && isset( $filtered_error['message'], $filtered_error['code'] ) ) {
+self::add_error( $errors, $path, (string) $filtered_error['code'], (string) $filtered_error['message'], (array) ( $filtered_error['meta'] ?? [] ) );
+} elseif ( is_string( $filtered_error ) ) {
+self::add_error( $errors, $path, 'validation_failed', $filtered_error );
+}
+}
+
+/**
+ * Validate repeater field entries.
+ */
+private static function validate_repeater_field( array &$errors, array $field, array $submission, array $form, string $path, bool $visible ): void {
+$key      = $field['key'] ?? '';
+$rows     = $submission[ $key ] ?? [];
+$required = ! empty( $field['required'] );
+
+if ( ! $visible ) {
+return;
+}
+
+if ( $required && ( ! is_array( $rows ) || empty( $rows ) ) ) {
+self::add_error( $errors, $path, 'required', $field['label'] ?? __( 'This field is required.', 'wp-betterforms' ) );
+
+return;
+}
+
+if ( empty( $rows ) ) {
+return;
+}
+
+if ( ! is_array( $rows ) ) {
+self::add_error( $errors, $path, 'invalid_repeater', __( 'Provide valid repeater data.', 'wp-betterforms' ) );
+
+return;
+}
+
+foreach ( $rows as $index => $row ) {
+$row_data = is_array( $row ) ? $row : [];
+
+foreach ( $field['fields'] ?? [] as $child ) {
+$child_key  = $child['key'] ?? '';
+$child_path = implode(
+ '.',
+ array_filter(
+ [ $path, (string) $index, $child_key ],
+ static fn( $segment ): bool => '' !== $segment && null !== $segment
+ )
+);
+self::validate_field( $errors, $child, $row_data, $form, $child_path );
+}
+}
+}
+
+/**
+ * Determine if the field should run validation based on conditional logic.
+ */
+private static function field_is_visible( array $field, array $submission ): bool {
+$conditions = $field['conditions'] ?? $field['logic'] ?? [];
+
+if ( empty( $conditions ) || empty( $conditions['rules'] ) || empty( $conditions['enabled'] ) ) {
+return true;
+}
+
+$type   = strtolower( $conditions['type'] ?? 'all' );
+$action = strtolower( $conditions['action'] ?? 'show' );
+$rules  = $conditions['rules'];
+
+$results = array_map(
+static function ( array $rule ) use ( $submission ): bool {
+$field_key = $rule['field'] ?? '';
+$operator  = strtolower( $rule['operator'] ?? 'equals' );
+$expected  = $rule['value'] ?? '';
+$actual    = $submission[ $field_key ] ?? null;
+
+return self::evaluate_condition( $actual, $operator, $expected );
+},
+$rules
+);
+
+$matched = 'all' === $type ? ! in_array( false, $results, true ) : in_array( true, $results, true );
+
+return 'show' === $action ? $matched : ! $matched;
+}
+
+/**
+ * Evaluate a single conditional rule.
+ */
+private static function evaluate_condition( $actual, string $operator, $expected ): bool {
+switch ( $operator ) {
+case 'not_equals':
+case '!=':
+return $actual != $expected;
+case 'contains':
+return is_string( $actual ) && str_contains( $actual, (string) $expected );
+case 'starts_with':
+return is_string( $actual ) && str_starts_with( $actual, (string) $expected );
+case 'ends_with':
+return is_string( $actual ) && str_ends_with( $actual, (string) $expected );
+case 'greater_than':
+case '>':
+return (float) $actual > (float) $expected;
+case 'less_than':
+case '<':
+return (float) $actual < (float) $expected;
+case 'in':
+$expected_values = is_array( $expected ) ? $expected : explode( ',', (string) $expected );
+
+return in_array( $actual, array_map( 'trim', $expected_values ), true );
+case 'not_in':
+$expected_values = is_array( $expected ) ? $expected : explode( ',', (string) $expected );
+
+return ! in_array( $actual, array_map( 'trim', $expected_values ), true );
+case 'empty':
+return self::is_empty( $actual );
+case 'not_empty':
+return ! self::is_empty( $actual );
+case 'equals':
+case '=':
+default:
+return $actual == $expected;
+}
+}
+
+/**
+ * Validate inventory limits.
+ */
+private static function validate_inventory( array &$errors, array $field, $value, array $submission, array $form, string $path ): void {
+$inventory = $field['inventory'] ?? [];
+
+if ( empty( $inventory ) || empty( $inventory['enabled'] ) ) {
+return;
+}
+
+$requested = is_array( $value ) ? count( $value ) : ( is_numeric( $value ) ? (int) $value : 1 );
+
+$remaining = apply_filters( 'wp_betterforms/inventory_remaining', null, $field, $requested, $submission, $form );
+
+if ( null === $remaining ) {
+if ( isset( $inventory['remaining'] ) ) {
+$remaining = (int) $inventory['remaining'];
+} elseif ( isset( $inventory['limit'] ) ) {
+$consumed  = (int) ( $inventory['consumed'] ?? 0 );
+$remaining = (int) $inventory['limit'] - $consumed;
+} else {
+return;
+}
+}
+
+if ( $requested > (int) $remaining ) {
+self::add_error(
+$errors,
+$path,
+'inventory_exhausted',
+__( 'Not enough inventory remaining for this selection.', 'wp-betterforms' ),
+[
+'requested' => $requested,
+'remaining' => (int) $remaining,
+]
+);
+}
+}
+
+/**
+ * Validate calculation fields against trusted expressions.
+ */
+private static function validate_calculation( array &$errors, array $field, $value, array $submission, array $form, string $path ): void {
+$calculation = $field['calculation'] ?? [];
+
+if ( empty( $calculation ) || empty( $calculation['enabled'] ) ) {
+return;
+}
+
+$expected = self::evaluate_calculation( (string) ( $calculation['formula'] ?? '' ), $submission );
+
+if ( null === $expected ) {
+return;
+}
+
+$tolerance = isset( $calculation['tolerance'] ) ? (float) $calculation['tolerance'] : 0.01;
+
+if ( ! is_numeric( $value ) || abs( (float) $value - $expected ) > $tolerance ) {
+self::add_error(
+$errors,
+$path,
+'calculation_mismatch',
+__( 'Calculated value does not match expected result.', 'wp-betterforms' ),
+[
+'expected'  => $expected,
+'provided'  => is_numeric( $value ) ? (float) $value : $value,
+'tolerance' => $tolerance,
+]
+);
+}
+}
+
+/**
+ * Evaluate calculation expression safely.
+ */
+private static function evaluate_calculation( string $formula, array $submission ): ?float {
+if ( '' === trim( $formula ) ) {
+return null;
+}
+
+$expression = preg_replace_callback(
+'~\{\{\s*([a-zA-Z0-9_\-\.]+)\s*\}\}~',
+static function ( array $matches ) use ( $submission ): string {
+$key   = $matches[1];
+$value = $submission[ $key ] ?? 0;
+
+return (string) ( is_numeric( $value ) ? (float) $value : 0 );
+},
+$formula
+);
+
+$expression = preg_replace( '/\s+/', '', (string) $expression );
+
+if ( preg_match( '/[^0-9+\-*\/\.\(\)]/', $expression ) ) {
+return null;
+}
+
+try {
+// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_eval
+$result = eval( 'return ' . $expression . ';' );
+} catch ( \Throwable ) {
+return null;
+}
+
+return is_numeric( $result ) ? (float) $result : null;
+}
+
+/**
+ * Validate server-trusted unique identifiers.
+ */
+private static function validate_unique_id( array &$errors, array $field, $value, array $submission, array $form, string $path ): void {
+$unique_config = $field['uniqueId'] ?? $field['unique_id'] ?? [];
+$type          = $field['type'] ?? '';
+
+if ( 'unique_id' === $type && self::is_empty( $value ) ) {
+self::add_error( $errors, $path, 'required', __( 'Unique identifier missing.', 'wp-betterforms' ) );
+
+return;
+}
+
+if ( empty( $unique_config ) && 'unique_id' !== $type ) {
+return;
+}
+
+$expected = apply_filters( 'wp_betterforms/unique_id_expected', null, $field, $submission, $form );
+
+if ( is_string( $expected ) && $expected !== '' ) {
+if ( (string) $value !== $expected ) {
+self::add_error( $errors, $path, 'unique_id_mismatch', __( 'Unique identifier mismatch.', 'wp-betterforms' ) );
+}
+
+return;
+}
+
+$mode = strtolower( $unique_config['mode'] ?? ( 'unique_id' === $type ? 'uuid' : '' ) );
+
+switch ( $mode ) {
+case 'uuid':
+if ( ! preg_match( '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', (string) $value ) ) {
+self::add_error( $errors, $path, 'invalid_uuid', __( 'Unique identifier must be a valid UUID.', 'wp-betterforms' ) );
+}
+break;
+case 'prefix':
+$prefix = (string) ( $unique_config['prefix'] ?? '' );
+$length = (int) ( $unique_config['length'] ?? 8 );
+
+if ( ! str_starts_with( (string) $value, $prefix ) || strlen( (string) $value ) < strlen( $prefix ) + $length ) {
+self::add_error( $errors, $path, 'invalid_unique_id', __( 'Unique identifier is not in the expected format.', 'wp-betterforms' ), [ 'prefix' => $prefix, 'length' => $length ] );
+}
+break;
+case 'hash':
+if ( ! preg_match( '/^[0-9a-f]{32}$/i', (string) $value ) ) {
+self::add_error( $errors, $path, 'invalid_hash', __( 'Unique identifier must be a valid hash.', 'wp-betterforms' ) );
 }
 break;
 default:
-// Extend via filters.
-$filtered_error = apply_filters( 'wp_betterforms/validate_field', null, $field, $value, $data, $form );
-if ( is_string( $filtered_error ) ) {
-$errors[ $key ] = $filtered_error;
+if ( self::is_empty( $value ) ) {
+self::add_error( $errors, $path, 'invalid_unique_id', __( 'Unique identifier is missing or malformed.', 'wp-betterforms' ) );
 }
 }
 }
 
-if ( ! empty( $errors ) ) {
-return new WP_Error( 'bf_validation_failed', __( 'Validation failed.', 'wp-betterforms' ), [ 'errors' => $errors, 'status' => 422 ] );
+/**
+ * Add a structured error entry.
+ */
+private static function add_error( array &$errors, string $path, string $code, string $message, array $meta = [] ): void {
+if ( ! isset( $errors[ $path ] ) ) {
+$errors[ $path ] = [];
 }
 
+$errors[ $path ][] = [
+'field'   => $path,
+'code'    => $code,
+'message' => $message,
+'meta'    => $meta,
+];
+}
+
+/**
+ * Determine if a value is considered empty for validation.
+ */
+private static function is_empty( $value ): bool {
+if ( null === $value ) {
 return true;
+}
+
+if ( is_string( $value ) ) {
+return '' === trim( $value );
+}
+
+if ( is_array( $value ) ) {
+return empty( $value );
+}
+
+return false;
 }
 }

--- a/wp-betterforms/tests/php/AdminNoticeTest.php
+++ b/wp-betterforms/tests/php/AdminNoticeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_BetterForms\Admin\Admin_Notices;
+
+final class AdminNoticeTest extends TestCase {
+public function test_notice_links_to_dashboard_widget(): void {
+$wpdb = new wpdb();
+$wpdb->tables[ $wpdb->prefix . 'bf_logs' ] = [
+[
+'id'         => 1,
+'form_id'    => 1,
+'type'       => 'email',
+'level'      => 'error',
+'created_at' => gmdate( 'Y-m-d H:i:s' ),
+],
+[
+'id'         => 2,
+'form_id'    => 1,
+'type'       => 'email',
+'level'      => 'error',
+'created_at' => gmdate( 'Y-m-d H:i:s' ),
+],
+[
+'id'         => 3,
+'form_id'    => 1,
+'type'       => 'email',
+'level'      => 'error',
+'created_at' => gmdate( 'Y-m-d H:i:s' ),
+],
+];
+$GLOBALS['wpdb'] = $wpdb;
+
+$notices = Admin_Notices::get_instance();
+ob_start();
+$notices->render_notice();
+$output = ob_get_clean();
+
+$this->assertStringContainsString( 'index.php#bf-email-queue', $output );
+$this->assertStringContainsString( 'email queue dashboard', strtolower( $output ) );
+}
+}

--- a/wp-betterforms/tests/php/RestSpamTest.php
+++ b/wp-betterforms/tests/php/RestSpamTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_BetterForms\Rest\Rest_Controller;
+
+final class RestSpamTest extends TestCase {
+protected function setUp(): void {
+parent::setUp();
+remove_all_filters( 'wp_betterforms/honeypot_min_time' );
+remove_all_filters( 'wp_betterforms/rate_limit_window' );
+remove_all_filters( 'wp_betterforms/rate_limit_max' );
+remove_all_filters( 'wp_betterforms/check_spam' );
+$GLOBALS['bf_test_transients'] = [];
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+}
+
+private function seed_form(): void {
+$schema = [
+'fields' => [
+[
+'key'      => 'email',
+'label'    => 'Email',
+'type'     => 'email',
+'required' => true,
+],
+],
+];
+
+$wpdb = new wpdb();
+$wpdb->tables[ $wpdb->prefix . 'bf_forms' ] = [
+[
+'id'          => 1,
+'title'       => 'Test',
+'slug'        => 'test',
+'schema_json' => json_encode( $schema ),
+'styles_json' => '{}',
+],
+];
+$wpdb->tables[ $wpdb->prefix . 'bf_email_queue' ] = [];
+$wpdb->tables[ $wpdb->prefix . 'bf_logs' ]        = [];
+$GLOBALS['wpdb'] = $wpdb;
+}
+
+private function make_request( array $data ): WP_Error|WP_REST_Response {
+$request = new WP_REST_Request();
+$request->set_param( 'form_id', 1 );
+$request->set_header( 'X-WP-Nonce', 'nonce-wp_rest' );
+$request->set_json_params( $data );
+
+return Rest_Controller::get_instance()->submit_form( $request );
+}
+
+public function test_honeypot_blocks_submission(): void {
+$this->seed_form();
+
+$result = $this->make_request( [
+'bf_hp'         => 'bot',
+'bf_rendered_at' => time() - 10,
+'email'         => 'human@example.com',
+] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$this->assertSame( 'bf_honeypot', $result->get_error_code() );
+}
+
+public function test_rate_limit_blocks_after_threshold(): void {
+$this->seed_form();
+add_filter( 'wp_betterforms/rate_limit_max', static fn() => 1 );
+set_transient( 'bf_rl_' . md5( '1|127.0.0.1' ), 1, 300 );
+
+$result = $this->make_request( [
+'bf_rendered_at' => time() - 10,
+'email'         => 'human@example.com',
+] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$this->assertSame( 'bf_rate_limited', $result->get_error_code() );
+}
+
+public function test_spam_filter_blocks_submission(): void {
+$this->seed_form();
+add_filter(
+'wp_betterforms/check_spam',
+static fn() => true
+);
+
+$result = $this->make_request( [
+'bf_rendered_at' => time() - 10,
+'email'         => 'human@example.com',
+] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$this->assertSame( 'bf_spam_detected', $result->get_error_code() );
+}
+}

--- a/wp-betterforms/tests/php/SchedulerTest.php
+++ b/wp-betterforms/tests/php/SchedulerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_BetterForms\Scheduler\Scheduler;
+
+final class SchedulerTest extends TestCase {
+protected function setUp(): void {
+parent::setUp();
+$GLOBALS['bf_test_wp_mail_results'] = [];
+}
+
+public function test_process_queue_updates_statuses_and_logs_failures(): void {
+$wpdb = new wpdb();
+$wpdb->tables[ $wpdb->prefix . 'bf_email_queue' ] = [
+[
+'id'         => 1,
+'form_id'    => 1,
+'entry_id'   => 1,
+'to_email'  => 'fail@example.com',
+'subject'    => 'Failure',
+'body_html'  => '<p>Test</p>',
+'status'     => 'pending',
+'attempts'   => 0,
+'created_at' => '2024-01-01 00:00:00',
+'updated_at' => '2024-01-01 00:00:00',
+],
+[
+'id'         => 2,
+'form_id'    => 1,
+'entry_id'   => 2,
+'to_email'  => 'pass@example.com',
+'subject'    => 'Success',
+'body_html'  => '<p>Test</p>',
+'status'     => 'pending',
+'attempts'   => 0,
+'created_at' => '2024-01-01 00:01:00',
+'updated_at' => '2024-01-01 00:01:00',
+],
+];
+$wpdb->tables[ $wpdb->prefix . 'bf_logs' ] = [];
+$GLOBALS['wpdb'] = $wpdb;
+$GLOBALS['bf_test_wp_mail_results'] = [ false, true ];
+
+Scheduler::get_instance()->process_queue();
+
+$queue = $wpdb->tables[ $wpdb->prefix . 'bf_email_queue' ];
+$this->assertSame( 'failed', $queue[0]['status'] );
+$this->assertSame( 'sent', $queue[1]['status'] );
+$this->assertSame( 1, $queue[0]['attempts'] );
+$this->assertSame( 1, $queue[1]['attempts'] );
+
+$logs = $wpdb->tables[ $wpdb->prefix . 'bf_logs' ];
+$this->assertNotEmpty( $logs );
+$this->assertSame( 'error', $logs[0]['level'] );
+$this->assertSame( 'email', $logs[0]['type'] );
+}
+}

--- a/wp-betterforms/tests/php/ValidatorTest.php
+++ b/wp-betterforms/tests/php/ValidatorTest.php
@@ -4,42 +4,193 @@ use PHPUnit\Framework\TestCase;
 use WP_BetterForms\Validation\Validator;
 
 final class ValidatorTest extends TestCase {
-public function test_detects_required_errors(): void {
-$form = [
-'schema' => [
-'fields' => [
-[
-'key'      => 'email',
-'label'    => 'Email',
-'required' => true,
-'type'     => 'email',
-],
-],
-],
-];
-
-$result = Validator::validate_submission( $form, [] );
-
-$this->assertInstanceOf( WP_Error::class, $result );
-$this->assertArrayHasKey( 'errors', $result->get_error_data() );
+protected function setUp(): void {
+parent::setUp();
+remove_all_filters( 'wp_betterforms/inventory_remaining' );
+remove_all_filters( 'wp_betterforms/validation_errors' );
 }
 
-public function test_allows_valid_submission(): void {
+public function test_detects_required_errors_with_condition_met(): void {
 $form = [
 'schema' => [
 'fields' => [
 [
-'key'      => 'email',
-'label'    => 'Email',
-'required' => true,
-'type'     => 'email',
+'key'        => 'name',
+'label'      => 'Name',
+'required'   => true,
+'conditions' => [
+'enabled' => true,
+'action'  => 'show',
+'type'    => 'all',
+'rules'   => [
+[
+'field'    => 'status',
+'operator' => 'equals',
+'value'    => 'yes',
+],
+],
+],
+],
+[
+'key'    => 'status',
+'label'  => 'Status',
+'type'   => 'select',
 ],
 ],
 ],
 ];
 
-$result = Validator::validate_submission( $form, [ 'email' => 'hello@example.com' ] );
+$result = Validator::validate_submission( $form, [ 'status' => 'yes' ] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$errors = $result->get_error_data()['errors']['name'][0];
+$this->assertSame( 'required', $errors['code'] );
+}
+
+public function test_skips_required_when_condition_not_met(): void {
+$form = [
+'schema' => [
+'fields' => [
+[
+'key'        => 'name',
+'label'      => 'Name',
+'required'   => true,
+'conditions' => [
+'enabled' => true,
+'action'  => 'show',
+'type'    => 'all',
+'rules'   => [
+[
+'field'    => 'status',
+'operator' => 'equals',
+'value'    => 'yes',
+],
+],
+],
+],
+[
+'key'    => 'status',
+'label'  => 'Status',
+'type'   => 'select',
+],
+],
+],
+];
+
+$result = Validator::validate_submission( $form, [ 'status' => 'no' ] );
 
 $this->assertTrue( $result );
+}
+
+public function test_inventory_limit_enforced(): void {
+add_filter(
+'wp_betterforms/inventory_remaining',
+static fn( $remaining ) => 2
+);
+
+$form = [
+'schema' => [
+'fields' => [
+[
+'key'       => 'tickets',
+'label'     => 'Tickets',
+'type'      => 'number',
+'inventory' => [
+'enabled' => true,
+],
+],
+],
+],
+];
+
+$result = Validator::validate_submission( $form, [ 'tickets' => 3 ] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$errors = $result->get_error_data()['errors']['tickets'][0];
+$this->assertSame( 'inventory_exhausted', $errors['code'] );
+$this->assertSame( 2, $errors['meta']['remaining'] );
+}
+
+public function test_calculation_mismatch_detected(): void {
+$form = [
+'schema' => [
+'fields' => [
+[
+'key'         => 'total',
+'label'       => 'Total',
+'type'        => 'number',
+'calculation' => [
+'enabled' => true,
+'formula' => '{{ quantity }} * {{ price }}',
+],
+],
+[
+'key' => 'quantity',
+],
+[
+'key' => 'price',
+],
+],
+],
+];
+
+$data   = [ 'quantity' => 2, 'price' => 10, 'total' => 15 ];
+$result = Validator::validate_submission( $form, $data );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$errors = $result->get_error_data()['errors']['total'][0];
+$this->assertSame( 'calculation_mismatch', $errors['code'] );
+}
+
+public function test_unique_identifier_pattern_enforced(): void {
+$form = [
+'schema' => [
+'fields' => [
+[
+'key'      => 'submission_id',
+'label'    => 'Submission ID',
+'type'     => 'unique_id',
+'uniqueId' => [
+'mode' => 'uuid',
+],
+],
+],
+],
+];
+
+$result = Validator::validate_submission( $form, [ 'submission_id' => 'not-a-uuid' ] );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$errors = $result->get_error_data()['errors']['submission_id'][0];
+$this->assertSame( 'invalid_uuid', $errors['code'] );
+}
+
+public function test_repeater_children_validated(): void {
+$form = [
+'schema' => [
+'fields' => [
+[
+'key'      => 'guests',
+'label'    => 'Guests',
+'type'     => 'repeater',
+'required' => true,
+'fields'   => [
+[
+'key'      => 'name',
+'label'    => 'Guest name',
+'required' => true,
+],
+],
+],
+],
+],
+];
+
+$data   = [ 'guests' => [ [ 'name' => '' ] ] ];
+$result = Validator::validate_submission( $form, $data );
+
+$this->assertInstanceOf( WP_Error::class, $result );
+$errors = $result->get_error_data()['errors']['guests.0.name'][0];
+$this->assertSame( 'required', $errors['code'] );
 }
 }

--- a/wp-betterforms/tests/php/bootstrap.php
+++ b/wp-betterforms/tests/php/bootstrap.php
@@ -3,10 +3,37 @@
  * PHPUnit bootstrap.
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+define( 'ABSPATH', __DIR__ . '/' );
+}
+
 require_once dirname( __DIR__, 2 ) . '/vendor/autoload.php';
 require_once dirname( __DIR__, 2 ) . '/includes/class-validator.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-logger.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-mailer.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-scheduler.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-admin-notices.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-rest.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-form-repository.php';
 
 define( 'WP_BETTERFORMS_TESTING', true );
+
+global $wp_filter;
+if ( ! is_array( $wp_filter ) ) {
+$wp_filter = [];
+}
+
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+define( 'ARRAY_A', 'ARRAY_A' );
+}
 
 if ( ! class_exists( 'WP_Error' ) ) {
 class WP_Error {
@@ -40,9 +67,45 @@ return $text;
 }
 }
 
+if ( ! function_exists( '_x' ) ) {
+function _x( string $text ): string {
+return $text;
+}
+}
+
 if ( ! function_exists( 'esc_html__' ) ) {
 function esc_html__( string $text ): string {
 return $text;
+}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+function esc_html( string $text ): string {
+return $text;
+}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+function esc_attr( string $text ): string {
+return $text;
+}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+function esc_url( string $url ): string {
+return $url;
+}
+}
+
+if ( ! function_exists( 'esc_js' ) ) {
+function esc_js( string $text ): string {
+return $text;
+}
+}
+
+if ( ! function_exists( 'admin_url' ) ) {
+function admin_url( string $path = '' ): string {
+return 'https://example.com/wp-admin/' . ltrim( $path, '/' );
 }
 }
 
@@ -52,8 +115,503 @@ return false !== filter_var( $email, FILTER_VALIDATE_EMAIL );
 }
 }
 
+if ( ! function_exists( 'sanitize_email' ) ) {
+function sanitize_email( string $email ): string {
+return strtolower( trim( $email ) );
+}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+function sanitize_text_field( $text ): string {
+return is_scalar( $text ) ? trim( (string) $text ) : '';
+}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+function sanitize_title( string $title ): string {
+return strtolower( preg_replace( '/[^a-z0-9-]/', '-', $title ) ?? '' );
+}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+function absint( $maybeint ): int {
+return abs( (int) $maybeint );
+}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+function sanitize_key( string $key ): string {
+return strtolower( preg_replace( '/[^a-z0-9_]/', '', $key ) ?? '' );
+}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+function wp_json_encode( $data ): string {
+return json_encode( $data );
+}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+function wp_kses_post( $content ) {
+return $content;
+}
+}
+
+if ( ! function_exists( 'maybe_serialize' ) ) {
+function maybe_serialize( $data ) {
+return is_array( $data ) || is_object( $data ) ? serialize( $data ) : $data;
+}
+}
+
+if ( ! function_exists( 'maybe_unserialize' ) ) {
+function maybe_unserialize( $data ) {
+$unserialized = @unserialize( $data );
+return false === $unserialized && 'b:0;' !== $data ? $data : $unserialized;
+}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+function current_time( string $type ): string {
+if ( 'mysql' === $type ) {
+return gmdate( 'Y-m-d H:i:s' );
+}
+
+return (string) time();
+}
+}
+
+if ( ! function_exists( 'wp_create_nonce' ) ) {
+function wp_create_nonce( string $action = '' ): string {
+return 'nonce-' . $action;
+}
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+function wp_verify_nonce( string $nonce, string $action ): bool {
+return $nonce === 'nonce-' . $action || 'valid' === $nonce;
+}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+function get_current_user_id(): int {
+return 1;
+}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+function current_user_can( string $cap ): bool {
+return true;
+}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+function is_wp_error( $thing ): bool {
+return $thing instanceof WP_Error;
+}
+}
+
+if ( ! function_exists( 'shortcode_atts' ) ) {
+function shortcode_atts( array $pairs, array $atts ): array {
+return array_merge( $pairs, $atts );
+}
+}
+
+if ( ! function_exists( 'rest_url' ) ) {
+function rest_url( string $path = '' ): string {
+return 'https://example.com/wp-json/' . ltrim( $path, '/' );
+}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+function get_option( string $name, $default = false ) {
+return $GLOBALS['bf_test_options'][ $name ] ?? ( $default ?: 'admin@example.com' );
+}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+function update_option( string $name, $value ): bool {
+$GLOBALS['bf_test_options'][ $name ] = $value;
+
+return true;
+}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+function esc_url_raw( string $url ): string {
+return $url;
+}
+}
+
+if ( ! function_exists( 'wp_unique_id' ) ) {
+function wp_unique_id( string $prefix = '' ): string {
+static $i = 0;
+$i++;
+return $prefix . $i;
+}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+global $wp_filter;
+$wp_filter[ $tag ][ $priority ][] = [ 'function' => $callback, 'accepted_args' => $accepted_args ];
+}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+function add_action( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+add_filter( $tag, $callback, $priority, $accepted_args );
+}
+}
+
+if ( ! function_exists( 'remove_all_filters' ) ) {
+function remove_all_filters( string $tag ): void {
+global $wp_filter;
+unset( $wp_filter[ $tag ] );
+}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
-function apply_filters( string $tag, $value ) {
+function apply_filters( string $tag, $value, ...$args ) {
+global $wp_filter;
+
+if ( empty( $wp_filter[ $tag ] ) ) {
 return $value;
 }
+
+ksort( $wp_filter[ $tag ] );
+
+foreach ( $wp_filter[ $tag ] as $callbacks ) {
+foreach ( $callbacks as $callback ) {
+$function      = $callback['function'];
+$accepted_args = $callback['accepted_args'];
+$value         = $function( $value, ...array_slice( $args, 0, $accepted_args - 1 ) );
+}
+}
+
+return $value;
+}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+function do_action( string $tag, ...$args ): void {
+global $wp_filter;
+
+if ( empty( $wp_filter[ $tag ] ) ) {
+return;
+}
+
+ksort( $wp_filter[ $tag ] );
+
+foreach ( $wp_filter[ $tag ] as $callbacks ) {
+foreach ( $callbacks as $callback ) {
+$function      = $callback['function'];
+$accepted_args = $callback['accepted_args'];
+$function( ...array_slice( $args, 0, $accepted_args ) );
+}
+}
+}
+}
+
+if ( ! function_exists( 'wp_add_dashboard_widget' ) ) {
+function wp_add_dashboard_widget( string $widget_id, string $title, callable $callback ): void {
+// no-op for tests
+}
+}
+
+if ( ! function_exists( 'wp_nonce_field' ) ) {
+function wp_nonce_field() {}
+}
+
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+function wp_enqueue_script() {}
+}
+
+if ( ! function_exists( 'wp_enqueue_style' ) ) {
+function wp_enqueue_style() {}
+}
+
+if ( ! function_exists( 'wp_localize_script' ) ) {
+function wp_localize_script() {}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+function get_transient( string $key ) {
+return $GLOBALS['bf_test_transients'][ $key ]['value'] ?? false;
+}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+function set_transient( string $key, $value, int $expiration ): void {
+$GLOBALS['bf_test_transients'][ $key ] = [ 'value' => $value, 'expires' => time() + $expiration ];
+}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+function delete_transient( string $key ): void {
+unset( $GLOBALS['bf_test_transients'][ $key ] );
+}
+}
+
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+function wp_next_scheduled( string $hook ) {
+return $GLOBALS['bf_test_cron'][ $hook ] ?? false;
+}
+}
+
+if ( ! function_exists( 'wp_schedule_event' ) ) {
+function wp_schedule_event( int $timestamp, string $recurrence, string $hook ): void {
+$GLOBALS['bf_test_cron'][ $hook ] = $timestamp;
+}
+}
+
+if ( ! function_exists( 'wp_unschedule_event' ) ) {
+function wp_unschedule_event( $timestamp, string $hook ): void {
+unset( $GLOBALS['bf_test_cron'][ $hook ] );
+}
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+function wp_mail( string $to, string $subject, string $message, array $headers = [] ) {
+if ( ! isset( $GLOBALS['bf_test_wp_mail_results'] ) ) {
+return true;
+}
+
+$result = array_shift( $GLOBALS['bf_test_wp_mail_results'] );
+
+return null === $result ? true : (bool) $result;
+}
+}
+
+if ( ! function_exists( 'wp_remote_post' ) ) {
+function wp_remote_post() {
+return [ 'body' => '{}', 'response' => [ 'code' => 200 ] ];
+}
+}
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+class WP_REST_Request {
+private array $params = [];
+private array $json_params = [];
+private array $headers = [];
+
+public function __construct( array $params = [], array $json_params = [], array $headers = [] ) {
+$this->params      = $params;
+$this->json_params = $json_params;
+$this->headers     = $headers;
+}
+
+public function get_param( string $key ) {
+return $this->params[ $key ] ?? null;
+}
+
+public function set_param( string $key, $value ): void {
+$this->params[ $key ] = $value;
+}
+
+public function get_json_params(): array {
+return $this->json_params;
+}
+
+public function set_json_params( array $params ): void {
+$this->json_params = $params;
+}
+
+public function get_header( string $key ): ?string {
+return $this->headers[ $key ] ?? null;
+}
+
+public function set_header( string $key, string $value ): void {
+$this->headers[ $key ] = $value;
+}
+}
+}
+
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+class WP_REST_Response {
+private array $data;
+
+public function __construct( array $data ) {
+$this->data = $data;
+}
+
+public function get_data(): array {
+return $this->data;
+}
+}
+}
+
+if ( ! class_exists( 'WP_REST_Server' ) ) {
+class WP_REST_Server {
+public const READABLE = 'GET';
+public const CREATABLE = 'POST';
+}
+}
+
+if ( ! function_exists( '__return_true' ) ) {
+function __return_true(): bool {
+return true;
+}
+}
+
+if ( ! function_exists( 'wp_add_inline_script' ) ) {
+function wp_add_inline_script() {}
+}
+
+if ( ! function_exists( 'wp_add_inline_style' ) ) {
+function wp_add_inline_style() {}
+}
+
+if ( ! function_exists( 'wp_dashboard_setup' ) ) {
+function wp_dashboard_setup() {}
+}
+
+if ( ! class_exists( 'wpdb' ) ) {
+class wpdb {
+public string $prefix = 'wp_';
+public int $insert_id = 0;
+public array $tables = [];
+private array $auto_ids = [];
+
+public function prepare( string $query, ...$args ): string {
+$query = str_replace( [ '%s', '%d', '%f' ], [ "'%s'", '%d', '%F' ], $query );
+
+return vsprintf( $query, $args );
+}
+
+public function insert( string $table, array $data ): void {
+$table_key = $this->normalize_table( $table );
+
+if ( ! isset( $this->auto_ids[ $table_key ] ) ) {
+$this->auto_ids[ $table_key ] = 1;
+}
+
+if ( empty( $data['id'] ) ) {
+$data['id'] = $this->auto_ids[ $table_key ]++;
+}
+
+$this->insert_id            = $data['id'];
+$this->tables[ $table_key ][] = $data;
+}
+
+public function update( string $table, array $data, array $where ): void {
+$table_key = $this->normalize_table( $table );
+
+foreach ( $this->tables[ $table_key ] ?? [] as $index => $row ) {
+$match = true;
+foreach ( $where as $key => $value ) {
+if ( ( $row[ $key ] ?? null ) != $value ) {
+$match = false;
+break;
+}
+}
+
+if ( $match ) {
+$this->tables[ $table_key ][ $index ] = array_merge( $row, $data );
+}
+}
+}
+
+public function get_results( string $query, string $output = ARRAY_A ): array {
+$table_key = $this->parse_table( $query );
+$rows      = $this->tables[ $table_key ] ?? [];
+
+if ( preg_match( "/WHERE\\s+status\\s*=\\s*'([^']+)'/i", $query, $status_match ) ) {
+$status = $status_match[1];
+$rows   = array_values(
+array_filter(
+$rows,
+static fn( array $row ): bool => ( $row['status'] ?? null ) === $status
+)
+);
+}
+
+if ( str_contains( strtolower( $query ), 'order by created_at asc' ) ) {
+usort(
+$rows,
+static fn( array $a, array $b ): int => strcmp( $a['created_at'] ?? '', $b['created_at'] ?? '' )
+);
+}
+
+if ( str_contains( strtolower( $query ), 'order by updated_at desc' ) ) {
+usort(
+$rows,
+static fn( array $a, array $b ): int => strcmp( $b['updated_at'] ?? '', $a['updated_at'] ?? '' )
+);
+}
+
+if ( preg_match( '/limit\s+(\d+)/i', $query, $limit_match ) ) {
+$rows = array_slice( $rows, 0, (int) $limit_match[1] );
+}
+
+return $rows;
+}
+
+public function get_row( string $query, string $output = ARRAY_A ) {
+$table_key = $this->parse_table( $query );
+$rows      = $this->tables[ $table_key ] ?? [];
+
+if ( preg_match( "/where\\s+id\\s*=\\s*(\d+)/i", $query, $id_match ) ) {
+$id = (int) $id_match[1];
+
+foreach ( $rows as $row ) {
+if ( (int) ( $row['id'] ?? 0 ) === $id ) {
+return $row;
+}
+}
+
+return null;
+}
+
+return $rows[0] ?? null;
+}
+
+public function get_var( string $query ) {
+$table_key = $this->parse_table( $query );
+$rows      = $this->tables[ $table_key ] ?? [];
+
+if ( preg_match( "/type\\s*=\\s*'([^']+)'/i", $query, $type_match ) ) {
+$type = $type_match[1];
+$rows = array_filter(
+$rows,
+static fn( array $row ): bool => ( $row['type'] ?? null ) === $type
+);
+}
+
+if ( preg_match( "/level\\s*=\\s*'([^']+)'/i", $query, $level_match ) ) {
+$level = $level_match[1];
+$rows  = array_filter(
+$rows,
+static fn( array $row ): bool => ( $row['level'] ?? null ) === $level
+);
+}
+
+if ( preg_match( "/created_at >= date_sub\( now\(\), interval (\d+) hour \)/i", strtolower( $query ), $hours_match ) ) {
+$threshold = time() - ( (int) $hours_match[1] * HOUR_IN_SECONDS );
+$rows      = array_filter(
+$rows,
+static function ( array $row ) use ( $threshold ): bool {
+return strtotime( $row['created_at'] ?? '' ) >= $threshold;
+}
+);
+}
+
+return count( $rows );
+}
+
+private function parse_table( string $query ): string {
+if ( preg_match( '/from\s+([a-z0-9_]+)/i', $query, $matches ) ) {
+return $this->normalize_table( $matches[1] );
+}
+
+return $this->normalize_table( 'wp_bf_forms' );
+}
+
+private function normalize_table( string $table ): string {
+return str_contains( $table, $this->prefix ) ? $table : $table;
+}
+}
+}
+
+if ( ! isset( $GLOBALS['wpdb'] ) ) {
+$GLOBALS['wpdb'] = new wpdb();
 }


### PR DESCRIPTION
## Summary
- expand the server-side validator to match client rules, including repeaters, inventory caps, calculation checks, unique IDs, and structured error payloads
- harden the submission REST endpoint with honeypot timing, rate limiting, captcha hooks, spam filters, and new email queue management routes plus an admin dashboard widget for failures
- extend the test harness and add PHPUnit coverage for validator rules, spam mitigation, scheduler retries, and admin notice messaging

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d8ace7e0cc83269f53fa9b6d729a91